### PR TITLE
Fix broken `sjcl.random.stopCollectors()` under Firefox 3.6

### DIFF
--- a/core/random.js
+++ b/core/random.js
@@ -193,8 +193,8 @@ sjcl.random = {
     if (!this._collectorsStarted) { return; }
   
     if (window.removeEventListener) {
-      window.removeEventListener("load", this._loadTimeCollector);
-      window.removeEventListener("mousemove", this._mouseCollector);
+      window.removeEventListener("load", this._loadTimeCollector, false);
+      window.removeEventListener("mousemove", this._mouseCollector, false);
     } else if (window.detachEvent) {
       window.detachEvent("onload", this._loadTimeCollector);
       window.detachEvent("onmousemove", this._mouseCollector);


### PR DESCRIPTION
I've just create pull request for [issue #24](https://github.com/bitwiseshiftleft/sjcl/issues/24)
