### PR TITLE
Fix OCB2 test dependecy checking

### DIFF
--- a/test/ocb2_test.js
+++ b/test/ocb2_test.js
@@ -1,5 +1,5 @@
 new sjcl.test.TestCase("OCB 2.0 mode tests", function (cb) {
-  if (!sjcl.cipher.aes) {
+  if (!sjcl.cipher.aes || !sjcl.mode.ocb2) {
     this.unimplemented();
     cb && cb();
     return;


### PR DESCRIPTION
'test/ocb2_test.js' doesn't check dependency on `sjcl.mode.ocb2`. Here's a trivial fix.
