### PR TITLE
fix authentication tag size parameter name

### DIFF
--- a/core/convenience.js
+++ b/core/convenience.js
@@ -56,7 +56,7 @@
     rp.key = password;
     
     /* do the encryption */
-    p.ct = sjcl.mode[p.mode].encrypt(prp, plaintext, p.iv, p.adata, p.tag);
+    p.ct = sjcl.mode[p.mode].encrypt(prp, plaintext, p.iv, p.adata, p.ts);
     
     return j.encode(j._subtract(p, j.defaults));
   },
@@ -100,7 +100,7 @@
     prp = new sjcl.cipher[p.cipher](password);
     
     /* do the decryption */
-    ct = sjcl.mode[p.mode].decrypt(prp, p.ct, p.iv, p.adata, p.tag);
+    ct = sjcl.mode[p.mode].decrypt(prp, p.ct, p.iv, p.adata, p.ts);
     
     /* return the json data */
     j._add(rp, p);


### PR DESCRIPTION
While reading convenience.js, I noticed that authentication tag in default parameters is named "ts", but later parametr "tag" is used. 
