### PR TITLE
added codecBase64 to convenience dependencies

### DIFF
--- a/configure
+++ b/configure
@@ -22,7 +22,7 @@ my %deps = ('aes'=>'sjcl',
             'ecc'=>'bn',
             'cbc'=>'bitArray,aes',
             'random'=>'sha256,aes',
-            'convenience'=>'ccm,pbkdf2,random');
+            'convenience'=>'ccm,pbkdf2,random,codecBase64');
             
 my $compress = "closure";
             


### PR DESCRIPTION
I'm pretty sure that convenience.js needs codecBase64.js, but it wasn't in the dependencies. I added it and everything seems to work properly.
