### PR TITLE
Fixed JSON format issue

### DIFF
--- a/core/convenience.js
+++ b/core/convenience.js
@@ -122,7 +122,7 @@
         if (!i.match(/^[a-z0-9]+$/i)) {
           throw new sjcl.exception.invalid("json encode: invalid property name");
         }
-        out += comma + i + ':';
+        out += comma + '"' + i + '"' + ':';
         comma = ',';
         
         switch (typeof obj[i]) {


### PR DESCRIPTION
Hi

According to http://json.org/ keys in JSON must be surrounded by double quotes.
My fork fixes this making PHP 'json_decode' able to decode it.
