### PR TITLE
Fixing a bug in the JSON parser

### DIFF
--- a/core/convenience.js
+++ b/core/convenience.js
@@ -160,7 +160,7 @@
     }
     var a = str.replace(/^\{|\}$/g, '').split(/,/), out={}, i, m;
     for (i=0; i<a.length; i++) {
-      if (!(m=a[i].match(/^([a-z][a-z0-9]*):(?:(\d+)|"([a-z0-9+\/%*_.@=\-]*)")$/i))) {
+      if (!(m=a[i].match(/^(?:"?([a-z][a-z0-9]*)"?):(?:(\d+)|"([a-z0-9+\/%*_.@=\-]*)")$/i))) {
         throw new sjcl.exception.invalid("json decode: this isn't json!");
       }
       if (m[2]) {


### PR DESCRIPTION
Fixing a bug in the JSON parser. I'm not very happy with this quick hack, since I think it should fall back on the native JSON parsers or use Douglas Crockford his JSON-js implementation. But at least it works for now.

The fix has been tested on the more recent Chrome, Firefox and Internet Explorer browsers on Windows.
