### PR TITLE
jsdoc: fix param names in misc.cachedPbkdf2

### DIFF
--- a/core/convenience.js
+++ b/core/convenience.js
@@ -255,8 +255,8 @@ sjcl.decrypt = sjcl.json.decrypt;
 sjcl.misc._pbkdf2Cache = {};
 
 /** Cached PBKDF2 key derivation.
- * @param {String} The password.  
- * @param {Object} The derivation params (iteration count and optional salt).
+ * @param {String} password The password.
+ * @param {Object} [params] The derivation params (iteration count and optional salt).
  * @return {Object} The derived data in key, the salt in salt.
  */
 sjcl.misc.cachedPbkdf2 = function (password, obj) {


### PR DESCRIPTION
minor documentation fix
