### PR TITLE
sjcl.random.addEntropy() and sjcl.random._loadTimeCollector() are broken

### DIFF
--- a/core/random.js
+++ b/core/random.js
@@ -100,12 +100,21 @@ sjcl.random = {
       break;
       
     case "object":
-      if (Object.prototype.toString.call(data) !== "[object Array]") {
-        err = 1;
-      }
-      for (i=0; i<data.length && !err; i++) {
-        if (typeof(data[i]) != "number") {
+      var objName = Object.prototype.toString.call(data);
+      if (objName === "[object Uint32Array]") {
+        tmp = [];
+        for (i = 0; i < data.length; i++) {
+          tmp.push(data[i]);
+        }
+        data = tmp;
+      } else {
+        if (objName !== "[object Array]") {
           err = 1;
+        }
+        for (i=0; i<data.length && !err; i++) {
+          if (typeof(data[i]) != "number") {
+            err = 1;
+          }
         }
       }
       if (!err) {


### PR DESCRIPTION
sjcl.random.addEntropy():
- Fixed bug: when data is a number, it is now added to this._pools
- Fixed bug: throws an exception when data is an object but not an array of numbers
- Removed unused variable "ty"

sjcl.random._loadTimeCollector():
- Fixed bug: now passes a number into sjcl.random.addEntropy() instead of an object
