### PR TITLE
sjcl.random improvements

### DIFF
--- a/core/random.js
+++ b/core/random.js
@@ -3,6 +3,7 @@
  * @author Emily Stark
  * @author Mike Hamburg
  * @author Dan Boneh
+ * @author Michael Brooks
  */
 
 /** @namespace Random number generator
@@ -40,6 +41,36 @@
  * </p>
  */
 sjcl.random = {
+  /** Prepare the entorpy pools for use.
+   */
+  init: function () {
+    /* sjcl.random is useless without the following line,  
+     * this should be started as soon as possilbe to collect the most
+     * entorpy*/
+	this.startCollectors();
+	
+	/*Initlize the entropy pool with information the attacker doesn't 
+	 *know*/
+	for(var x=0; x<48; x++){
+	  r = this._platformPRNG();
+	  this.addEntropy(r, 1, "init");
+	}
+	
+	/*We should be over https and these would be valid secrets.
+	 * Worst case adding more data doesn't hurt*/
+	this.addEntropy(document.cookie, 0, "cookie");
+	this.addEntropy(document.location.href, 0, "location");
+	
+	/*If sjcl.random has run before then we should have a preivous 
+	 * state to draw from*/
+	this._loadPoolState();
+    if (window.addEventListener) {
+      window.addEventListener("beforeunload", this._savePoolState, false);
+    } else if (document.attachEvent) {
+      document.attachEvent("onbeforeunload", this._savePoolState);
+    }	
+  },
+	
   /** Generate several random words, and return them in an array
    * @param {Number} nwords The number of words to generate.
    */
@@ -81,6 +112,7 @@ sjcl.random = {
     var id,
       i, tmp,
       t = (new Date()).valueOf(),
+      r = this._platformPRNG(),
       robin = this._robins[source],
       oldReady = this.isReady(), err = 0;
       
@@ -96,7 +128,7 @@ sjcl.random = {
       if (estimatedEntropy === undefined) {
         estimatedEntropy = 1;
       }
-      this._pools[robin].update([id,this._eventId++,1,estimatedEntropy,t,1,data|0]);
+      this._pools[robin].update([id,this._eventId++,1,estimatedEntropy,t,r,1,data|0]);
       break;
       
     case "object":
@@ -129,7 +161,7 @@ sjcl.random = {
             }
           }
         }
-        this._pools[robin].update([id,this._eventId++,2,estimatedEntropy,t,data.length].concat(data));
+        this._pools[robin].update([id,this._eventId++,2,estimatedEntropy,t,r,data.length].concat(data));
       }
       break;
       
@@ -141,10 +173,10 @@ sjcl.random = {
         */
        estimatedEntropy = data.length;
       }
-      this._pools[robin].update([id,this._eventId++,3,estimatedEntropy,t,data.length]);
+      this._pools[robin].update([id,this._eventId++,3,estimatedEntropy,t,r,data.length]);
       this._pools[robin].update(data);
       break;
-      
+
     default:
       err=1;
     }
@@ -198,11 +230,13 @@ sjcl.random = {
     if (this._collectorsStarted) { return; }
   
     if (window.addEventListener) {
-      window.addEventListener("load", this._loadTimeCollector, false);
       window.addEventListener("mousemove", this._mouseCollector, false);
+      window.addEventListener("keypress", this._keyboardCollector, false);
+      window.addEventListener("devicemotion", this._accelerometerCollector, false);
     } else if (document.attachEvent) {
-      document.attachEvent("onload", this._loadTimeCollector);
       document.attachEvent("onmousemove", this._mouseCollector);
+      document.attachEvent("onkeypress", this._keyboardCollector);
+      document.attachEvent("ondevicemotion", this._accelerometerCollector);
     }
     else {
       throw new sjcl.exception.bug("can't attach event");
@@ -216,19 +250,16 @@ sjcl.random = {
     if (!this._collectorsStarted) { return; }
   
     if (window.removeEventListener) {
-      window.removeEventListener("load", this._loadTimeCollector, false);
       window.removeEventListener("mousemove", this._mouseCollector, false);
+      window.removeEventListener("keypress", this._keyboardCollector, false);
+      window.removeEventListener("devicemotion", this._accelerometerCollector, false);      
     } else if (window.detachEvent) {
-      window.detachEvent("onload", this._loadTimeCollector);
       window.detachEvent("onmousemove", this._mouseCollector);
+      window.detachEvent("onkeypress", this._keyboardCollector);
+      window.detachEvent("ondevicemotion", this._accelerometerCollector);      
     }
     this._collectorsStarted = false;
   },
-  
-  /* use a cookie to store entropy.
-  useCookie: function (all_cookies) {
-      throw new sjcl.exception.bug("random: useCookie is unimplemented");
-  },*/
   
   /** add an event listener for progress or seeded-ness. */
   addEventListener: function (name, callback) {
@@ -274,6 +305,7 @@ sjcl.random = {
   _defaultParanoia         : 6,
   
   /* event listener stuff */
+  _initilized              : false,
   _collectorsStarted       : false,
   _callbacks               : {progress: {}, seeded: {}},
   _callbackI               : 0,
@@ -332,7 +364,7 @@ sjcl.random = {
       /* On some browsers, this is cryptographically random.  So we might
        * as well toss it in the pot and stir...
        */
-      reseedData.push(Math.random()*0x100000000|0);
+      reseedData.push(this._platformPRNG());
     }
     
     for (i=0; i<this._pools.length; i++) {
@@ -359,14 +391,24 @@ sjcl.random = {
     this._reseed(reseedData);
   },
   
+  _keyboardCollector: function (ev) {
+    var chCode = ('charCode' in ev) ? ev.charCode : ev.keyCode;
+    sjcl.random.addEntropy(chCode, 1, "keyboard");
+  },  
+  
   _mouseCollector: function (ev) {
     var x = ev.x || ev.clientX || ev.offsetX || 0, y = ev.y || ev.clientY || ev.offsetY || 0;
     sjcl.random.addEntropy([x,y], 2, "mouse");
   },
   
-  _loadTimeCollector: function (ev) {
-    sjcl.random.addEntropy((new Date()).valueOf(), 2, "loadtime");
-  },
+  _accelerometerCollector: function (ev) {
+	var ac = ev.accelerationIncludingGravity.x||ev.accelerationIncludingGravity.y||ev.accelerationIncludingGravity.z;
+	var or = "";
+	if(window.orientation){
+       or = window.orientation;
+	}
+    sjcl.random.addEntropy([ac,or], 3, "accelerometer");
+  },    
   
   _fireEvent: function (name, arg) {
     var j, cbs=sjcl.random._callbacks[name], cbsTemp=[];
@@ -385,16 +427,43 @@ sjcl.random = {
     for (j=0; j<cbsTemp.length; j++) {
      cbsTemp[j](arg);
     }
-  }
+  },
+  
+  _savePoolState: function (ev) {
+    if(window.localStorage){
+		window.localStorage.setItem("sjcl.random",sjcl.random._gen4words());
+	}
+  },
+  
+  _loadPoolState: function () {
+	 if(window.localStorage){
+	    var r= window.localStorage.getItem("sjcl.random");
+	    if(r){
+		  /* Assume the worst, that localStorage was compromised with
+		   * XSS and therefore contributes a worst case of 0 entropy*/
+	      sjcl.random.addEntropy(r, 0, "loadpool");
+	    }
+	 }
+  },
+  
+  /** Return the best random value aviable to this script.
+   */
+  _platformPRNG: function () {
+	  var ret;
+	  if(typeof window.crypto.getRandomValues == 'function'){
+         var ab = new Uint32Array(1);
+		 window.crypto.getRandomValues(ab);
+		 ret = ab[0];
+      }else{
+		  /*This is the best we can do,  
+		   *this method is cryptographically random on some platforms*/
+		  ret = Math.random()*0x100000000|0;
+	  }
+	  return ret;
+  },
 };
 
 (function(){
-  try {
-    // get cryptographically strong entropy in Webkit
-    var ab = new Uint32Array(32);
-    crypto.getRandomValues(ab);
-    sjcl.random.addEntropy(ab, 1024, "crypto.getRandomValues");
-  } catch (e) {
-    // no getRandomValues :-(
-  }
+   /*Make sure the sjcl.random is ready to use*/
+   sjcl.random.init();
 })();


### PR DESCRIPTION
This change covers what we talked about in issue #77.   There isn't a lot of code here so it should be pretty easy to review.  The init() method is new.  The entropy pool is always initialized to 48,  and if you think it should be 0 then I will be the last person to criticize you for being paranoid.   I am happy to discuss any of the changes I made and there is still room for improvement.

Here is a list of changes:
Better support for mobile devices.
Added new sources of entropy.
Supports saving and restoring entropy from localStorage.
Stronger randomness at initialization (especially for non-chrome browsers!).
