### PR TITLE
Publish sjcl as package in npm registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+    "name": "sjcl",
+    "version": "0.0.1",
+    "description": "Stanford Javascript Crypto Library",
+    "main": "sjcl.js",
+    "author": "bitwiseshiftleft",
+    "keywords": ["encryption", "high-level", "crypto"],
+    "repository" : {
+        "type": "git",
+        "url": "https://github.com/bitwiseshiftleft/sjcl.git"
+    },
+    "engines": { "node": "*" }
+}


### PR DESCRIPTION
I added a package.json file, so that sjcl can be easily be added to the npm registry.

Since you are the author, I thought it would make sense for you to publish the module. All thats left is to call the following two commands from your terminal from inside the git repo:

  npm adduser
  npm publish

https://npmjs.org/doc/developers.html
