### PR TITLE
Travis CI Support (Free Test Server)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+before_install:
+  - sudo apt-get install -qq rhino
+script: make test

--- a/test/run_tests_rhino.js
+++ b/test/run_tests_rhino.js
@@ -7,5 +7,8 @@ for (var i=0; i<arguments.length; i++) {
   if (!file.match(/^-/)) load(file);
 }
 
-sjcl.test.run();
-
+sjcl.test.run(undefined, function(){
+  if(!browserUtil.allPassed) {
+    throw "All tests complete, but some failed!";
+  }
+});


### PR DESCRIPTION
I just discovered that [Travis CI](https://travis-ci.org/) is free for open-source projects, and very easy to use.

All that's necessary is:
- Add a `.travis.yml` file to the repo.
- Somebody with admin privileges for the project signs up for https://travis-ci.org/ (using GitHub) and enables it for the project.

Then any commit or pull request associated with the repository triggers Travis CI to run unit tests immediately, and the results show up with nice little indicators on GitHub (as well as being visible on Travis CI and emailed to contributors).

I had to modify the Rhino tests to throw an exception in case of failure, but it's reporting the build status correctly for my fork: https://travis-ci.org/lgarron/sjcl/builds
Successful build: https://travis-ci.org/lgarron/sjcl/builds/12475415
Failed build: https://travis-ci.org/lgarron/sjcl/builds/12475430

(Tests should probably be moved to `node.js`, which should be faster -- and natively supported by Travis. But I didn't want to do that simultaneously.)
