### PR TITLE
Add ignore section to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,12 @@
 {
 	"name": "sjcl",
 	"version": "1.0.0",
-	"main": ["./sjcl.js"]
+	"main": ["./sjcl.js"],
+	"ignore": [
+		"**/*",
+		"!README.md",
+		"!README/*",
+		"!bower.json",
+		"!sjcl.js"
+	]
 }


### PR DESCRIPTION
Add ignore section to reduce bower install download from +10MB to just the default sjcl.js plus READMEs
