### PR TITLE
fix entropy data array detection

### DIFF
--- a/core/random.js
+++ b/core/random.js
@@ -151,7 +151,7 @@ sjcl.prng.prototype = {
         }
         data = tmp;
       } else {
-        if (objName !== "[object Array]") {
+        if (data[0] == null) {
           err = 1;
         }
         for (i=0; i<data.length && !err; i++) {


### PR DESCRIPTION
It turns out that node.js crypt.randomBytes is not array(but can be indexed), so addEntropy fails with "addEntropy only supports number, array of numbers or string".
