### PR TITLE
commonjs client-side wrapper use

### DIFF
--- a/core/random.js
+++ b/core/random.js
@@ -450,9 +450,7 @@ sjcl.random = new sjcl.prng(6);
   try {
     var buf, crypt, getRandomValues, ab;
     // get cryptographically strong entropy depending on runtime environment
-    if (typeof module !== 'undefined' && module.exports) {
-      // get entropy for node.js
-      crypt = require('crypto');
+    if (typeof module !== 'undefined' && module.exports && (crypt = require('crypto')) && crypt.randomBytes) {
       buf = crypt.randomBytes(1024/8);
       sjcl.random.addEntropy(buf, 1024, "crypto.randomBytes");
 


### PR DESCRIPTION
commonjs module wrappers like browserify can emulate nodejs environment but not provide all native nodejs modules like crypto
so the check `typeof module !== 'undefined' && module.exports` is not sufficient as for example browserify provide method `require` and gracefully handle a call of a non existing module
`require('crypto')` returns an empty object and the whole following procedure of entropy addition fails
