### PR TITLE
Use console only if it is available.

### DIFF
--- a/core/random.js
+++ b/core/random.js
@@ -476,8 +476,10 @@ sjcl.random = new sjcl.prng(6);
       // no getRandomValues :-(
     }
   } catch (e) {
-    console.log("There was an error collecting entropy from the browser:");
-    console.log(e);
-    //we do not want the library to fail due to randomness not being maintained.
+    if (typeof window !== 'undefined' && window.console) {
+      console.log("There was an error collecting entropy from the browser:");
+      console.log(e);
+      //we do not want the library to fail due to randomness not being maintained.
+    }
   }
 }());


### PR DESCRIPTION
When using sjcl within a web worker, window as well as window.console is not available. That makes firefox (and perhaps others) stop execution. This makes sure console is available before using it.
