### PR TITLE
Fix Issue #131

### DIFF
--- a/core/codecString.js
+++ b/core/codecString.js
@@ -17,7 +17,7 @@ sjcl.codec.utf8String = {
       out += String.fromCharCode(tmp >>> 24);
       tmp <<= 8;
     }
-    return decodeURIComponent(encodeURIComponent(out));
+    return out;
   },
   
   /** Convert from a UTF-8 string to a bitArray. */


### PR DESCRIPTION
It is not the job of the library to encode and decode string if it makes the function unusable.

It is the developers job to do so.
