### PR TITLE
Added additional listeners to allow entropy collection off of the touchm...

### DIFF
--- a/core/random.js
+++ b/core/random.js
@@ -407,7 +407,7 @@ sjcl.prng.prototype = {
     var x = touch.pageX || touch.clientX,
         y = touch.pageY || touch.clientY;
 
-    sjcl.random.addEntropy([x,y],2,"touch");
+    sjcl.random.addEntropy([x,y],1,"touch");
 
     this._addCurrentTimeToEntropy(0);
   },


### PR DESCRIPTION
Added an additional collector to be able to collect entropy off of the touchmove event on mobile devices.

The mousemove collector does not work very well on mobile devices (IOS / Android) and it would be nice to be able to utilize the touch based events for entropy as well as the devicemotion.
