### PR TITLE
Base58 using sjcl.bn

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,7 @@ TEST_COMMON=  browserTest/nodeUtil.js test/test.js
 
 TEST_SCRIPTS= $(TEST_COMMON) \
               test/aes_vectors.js test/aes_test.js \
+              test/base58_vectors.js test/base58_test.js \
               test/ocb2_vectors.js test/ocb2_test.js  \
               test/ccm_vectors.js test/ccm_test.js  \
               test/cbc_vectors.js test/cbc_test.js  \

--- a/config.mk
+++ b/config.mk
@@ -1,2 +1,2 @@
-SOURCES= core/sjcl.js core/aes.js core/bitArray.js core/codecString.js core/codecHex.js core/codecBase64.js core/sha256.js core/ccm.js core/ocb2.js core/gcm.js core/hmac.js core/pbkdf2.js core/random.js core/convenience.js 
+SOURCES= core/sjcl.js core/aes.js core/bitArray.js core/codecString.js core/codecHex.js core/codecBase58.js core/codecBase64.js core/codecBytes.js core/sha256.js core/sha512.js core/sha1.js core/ccm.js core/cbc.js core/ocb2.js core/gcm.js core/hmac.js core/pbkdf2.js core/random.js core/convenience.js core/bn.js core/ecc.js core/srp.js 
 COMPRESS= core_closure.js

--- a/configure
+++ b/configure
@@ -4,11 +4,12 @@ use strict;
 
 my ($arg, $i, $j, $targ);
 
-my @targets = qw/sjcl aes bitArray codecString codecHex codecBase64 codecBytes sha256 sha512 sha1 ccm cbc ocb2 gcm hmac pbkdf2 random convenience bn ecc srp/;
+my @targets = qw/sjcl aes bitArray codecString codecHex codecBase58 codecBase64 codecBytes sha256 sha512 sha1 ccm cbc ocb2 gcm hmac pbkdf2 random convenience bn ecc srp/;
 my %deps = ('aes'=>'sjcl',
             'bitArray'=>'sjcl',
             'codecString'=>'bitArray',
             'codecHex'=>'bitArray',
+            'codecBase58'=>'bitArray,bn,codecHex',
             'codecBase64'=>'bitArray',
             'codecBytes'=>'bitArray',
             'sha256'=>'codecString',
@@ -31,7 +32,7 @@ my $compress = "closure";
 my %enabled = ();
 $enabled{$_} = 0 foreach (@targets);
 
-# by default, all but codecBytes, srp, bn
+# by default, all but codecBytes, srp, bn, base58
 $enabled{$_} = 1 foreach (qw/aes bitArray codecString codecHex codecBase64 sha256 ccm ocb2 gcm hmac pbkdf2 random convenience/);
 
 # argument parsing

--- a/core/codecBase58.js
+++ b/core/codecBase58.js
@@ -1,0 +1,110 @@
+sjcl.codec.base58 = {
+
+  _chars: "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz",
+
+  fromBits: function(arr) {
+    if (sjcl.bitArray.bitLength(arr) > 0) {
+      var x = sjcl.bn.fromBits(arr),
+          modulus = sjcl.bn.fromBits(arr),
+          out = '',
+          c = sjcl.codec.base58._chars;
+
+      while (x.greaterEquals(1)) {
+        var result = this._divmod58(x),
+            x = result.q,
+            charIndex = result.n.getLimb(0);
+
+        out = c[charIndex] + out;
+      }
+
+      var hex = sjcl.codec.hex.fromBits(arr),
+          zeros = hex.match(/^0*/)[0].length,
+          zeroBytes = Math.floor(zeros/2);
+
+      for (var i=zeroBytes; i>0; i--) {
+        out = "1" + out;
+      }
+
+      return out;
+    } else {
+      return '';
+    }
+  },
+
+  toBits: function(str) {
+    var powersOf58 = this._powersOf58(str.length);
+    var value = new sjcl.bn(), i, c = sjcl.codec.base58._chars, bitCount = 0;
+    for (i=0; i<str.length; i++) {
+      x   = c.indexOf(str.charAt(i));
+      pos = str.length - i - 1;
+      if (x < 0) {
+        throw new sjcl.exception.invalid("this isn't base58!");
+      }
+
+      addend = (new sjcl.bn(x)).mul(powersOf58[pos]);
+      value.addM(addend);
+    }
+
+    if (str.length > 0) {
+      var trimmedValue = value.trim(),
+          hexValue = trimmedValue == 0 ? '' : trimmedValue.toString().substr(2),
+          zeros    = str.match(/^1*/)[0].length,
+          bitCount = hexValue.length * 4 + zeros * 8;
+
+      return trimmedValue.toBits(bitCount);
+    } else {
+      return '';
+    }
+  },
+
+  _divmod58: function(n) {
+    var result = {
+      q: new sjcl.bn(0),
+      n: new sjcl.bn(n)
+    }
+    var d = new sjcl.bn(58);
+    var powerOf58 = new sjcl.bn(1), powersOf58table = [powerOf58];
+
+    // find max power of 58 that is less than n and build a power of 58 table
+    while (result.n.greaterEquals(powerOf58)) {
+      powersOf58table.push(powerOf58);
+      powerOf58 = powerOf58.mul(d);
+    }
+
+    while (result.n.greaterEquals(d)) {
+      var i = powersOf58table.length - 1, addToQ = 1;
+
+      if (powersOf58table.length > 1) {
+        addToQ = powersOf58table[i-1];
+      }
+
+      powerOf58 = powersOf58table[i];
+      while (powerOf58.greaterEquals(result.n.add(1))) {
+        i--;
+        powerOf58 = powersOf58table[i];
+        addToQ    = powersOf58table[i-1];
+      }
+
+      result.n.subM(powerOf58);
+      result.q.addM(addToQ);
+
+      result.n.normalize();
+    }
+
+    return result;
+  },
+
+  _powersOf58: function(maxPower) {
+    var out = [
+      new sjcl.bn(1)
+    ];
+
+    for (i=1;i<=maxPower;i++) {
+      var result = (new sjcl.bn(58)).mul(out[i-1]);
+      out.push(result);
+    }
+
+    return out;
+  }
+
+}

--- a/core/codecBase58.js
+++ b/core/codecBase58.js
@@ -97,10 +97,10 @@ sjcl.codec.base58 = {
   _powersOf58: function(maxPower) {
     var out = [
       new sjcl.bn(1)
-    ];
+    ], fiftyEight = new sjcl.bn(58);
 
     for (var i=1;i<=maxPower;i++) {
-      var result = (new sjcl.bn(58)).mul(out[i-1]);
+      var result = fiftyEight.mul(out[i-1]);
       out.push(result);
     }
 

--- a/core/codecBase58.js
+++ b/core/codecBase58.js
@@ -10,7 +10,7 @@ sjcl.codec.base58 = {
           c = sjcl.codec.base58._chars;
 
       while (x.greaterEquals(1)) {
-        var result = this._divmod58(x),
+        var result = sjcl.codec.base58._divmod58(x),
             x = result.q,
             charIndex = result.n.getLimb(0);
 
@@ -32,9 +32,9 @@ sjcl.codec.base58 = {
   },
 
   toBits: function(str) {
-    var powersOf58 = this._powersOf58(str.length);
-    var value = new sjcl.bn(), i, c = sjcl.codec.base58._chars, bitCount = 0;
-    for (i=0; i<str.length; i++) {
+    var powersOf58 = sjcl.codec.base58._powersOf58(str.length);
+    var value = new sjcl.bn(), i, c = sjcl.codec.base58._chars, bitCount = 0, x, pos, addend;
+    for (var i=0; i<str.length; i++) {
       x   = c.indexOf(str.charAt(i));
       pos = str.length - i - 1;
       if (x < 0) {
@@ -99,7 +99,7 @@ sjcl.codec.base58 = {
       new sjcl.bn(1)
     ];
 
-    for (i=1;i<=maxPower;i++) {
+    for (var i=1;i<=maxPower;i++) {
       var result = (new sjcl.bn(58)).mul(out[i-1]);
       out.push(result);
     }

--- a/test/base58_test.js
+++ b/test/base58_test.js
@@ -1,0 +1,21 @@
+new sjcl.test.TestCase("Base58 tests", function (cb) {
+  if (!sjcl.codec.base58) {
+    this.unimplemented();
+    cb && cb();
+    return;
+  }
+
+  var i, kat = sjcl.test.vector.base58, tv, h=sjcl.codec.hex, bits, hex;
+  for (i=0; i<kat.length; i++) {
+    tv = kat[i];
+    bits = sjcl.codec.base58.toBits(tv.base58);
+    this.require(sjcl.bitArray.equal(bits, h.toBits(tv.hex)), "Test failed for vector " + tv.base58 + " " + tv.hex);
+  }
+
+  for (i=0; i<kat.length; i++) {
+    tv = kat[i];
+    base58 = sjcl.codec.base58.fromBits(h.toBits(tv.hex));
+    this.require(base58 === tv.base58, "Test failed for vector " + tv.base58 + " " + tv.hex);
+  }
+  cb && cb();
+});

--- a/test/base58_vectors.js
+++ b/test/base58_vectors.js
@@ -1,0 +1,14 @@
+sjcl.test.vector.base58 = [
+  { base58: "", hex: "" },
+  { base58: "2g", hex: "61" },
+  { base58: "a3gV", hex: "626262" },
+  { base58: "aPEr", hex: "636363" },
+  { base58: "2cFupjhnEsSn59qHXstmK2ffpLv2", hex: "73696d706c792061206c6f6e6720737472696e67" },
+  { base58: "1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L", hex: "00eb15231dfceb60925886b67d065299925915aeb172c06647" },
+  { base58: "ABnLTmg", hex: "516b6fcd0f" },
+  { base58: "3SEo3LWLoPntC", hex: "bf4f89001e670274dd" },
+  { base58: "3EFU7m", hex: "572e4794" },
+  { base58: "EJDM8drfXA6uyA", hex: "ecac89cad93923c02321" },
+  { base58: "Rt5zm", hex: "10c8511e" },
+  { base58: "1111111111", hex: "00000000000000000000" }
+];

--- a/test/run_tests_browser.js
+++ b/test/run_tests_browser.js
@@ -4,6 +4,8 @@ function testCore(coreName, cb) {
     "test.js",
     "aes_test.js",
     "aes_vectors.js",
+    "base58_test.js",
+    "base58_vectors.js",
     "ccm_test.js",
     "ccm_vectors.js",
     "cbc_test.js",


### PR DESCRIPTION
My attempt at #155

This is a "Bitcoin" style Base58 (https://en.bitcoin.it/wiki/Base58Check_encoding)
* Uses the characters `123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz`
* Leading zeros are encoded to 1's

It works, but performance might be an issue... I'm open to suggestions. I tried to stick with what was already available in sjcl.