### PR TITLE
add Keccak, Sponge, SHA3, SHAKE and sjcl.bitArrayLE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ TEST_COMMON=  browserTest/nodeUtil.js test/test.js
 
 TEST_SCRIPTS= $(TEST_COMMON) \
               test/aes_vectors.js test/aes_test.js \
-              test/bitArray_vectors.js test/bitArray_test.js \
+              test/bitArray_vectors.js test/bitArray_test.js test/bitArrayLE_test.js \
               test/ocb2_vectors.js test/ocb2_test.js  \
               test/ccm_vectors.js test/ccm_test.js  \
               test/cbc_vectors.js test/cbc_test.js  \

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,7 @@ TEST_SCRIPTS= $(TEST_COMMON) \
               test/sha512_vectors.js test/sha512_test.js \
               test/sha512_test_brute_force.js \
               test/sha1_vectors.js test/sha1_test.js \
+              test/sha3_vectors.js test/sha3_test.js \
               test/hmac_vectors.js test/hmac_test.js \
               test/pbkdf2_test.js \
               test/bn_vectors.js test/bn_test.js \

--- a/configure
+++ b/configure
@@ -4,7 +4,7 @@ use strict;
 
 my ($arg, $i, $j, $targ);
 
-my @targets = qw/sjcl aes bitArray bitArrayLE codecString codecHex codecBase32 codecBase64 codecBytes sha256 sha512 sha1 ccm cbc ocb2 gcm hmac pbkdf2 random convenience bn ecc srp/;
+my @targets = qw/sjcl aes bitArray bitArrayLE codecString codecHex codecBase32 codecBase64 codecBytes sha256 sha512 sha1 sponge keccak_f sha3 ccm cbc ocb2 gcm hmac pbkdf2 random convenience bn ecc srp/;
 my %deps = ('aes'=>'sjcl',
             'bitArray'=>'sjcl',
             'bitArrayLE'=>'bitArray',
@@ -16,6 +16,9 @@ my %deps = ('aes'=>'sjcl',
             'sha256'=>'codecString',
             'sha512'=>'codecString',
             'sha1'=>'codecString',
+            'keccak_f'=>'sjcl',
+            'sponge'=>'codecString,bitArrayLE',
+            'sha3'=>'keccak_f,sponge',
             'ccm'=>'bitArray,aes',
             'ocb2'=>'bitArray,aes',
             'gcm'=>'bitArray,aes',

--- a/configure
+++ b/configure
@@ -4,9 +4,10 @@ use strict;
 
 my ($arg, $i, $j, $targ);
 
-my @targets = qw/sjcl aes bitArray codecString codecHex codecBase32 codecBase64 codecBytes sha256 sha512 sha1 ccm cbc ocb2 gcm hmac pbkdf2 random convenience bn ecc srp/;
+my @targets = qw/sjcl aes bitArray bitArrayLE codecString codecHex codecBase32 codecBase64 codecBytes sha256 sha512 sha1 ccm cbc ocb2 gcm hmac pbkdf2 random convenience bn ecc srp/;
 my %deps = ('aes'=>'sjcl',
             'bitArray'=>'sjcl',
+            'bitArrayLE'=>'bitArray',
             'codecString'=>'bitArray',
             'codecHex'=>'bitArray',
             'codecBase64'=>'bitArray',

--- a/core/bitArrayLE.js
+++ b/core/bitArrayLE.js
@@ -1,0 +1,309 @@
+/** @fileOverview Arrays of bits, encoded as arrays of little endian Numbers.
+ *
+ * @author Stefan Bühler
+ */
+
+/** @namespace Arrays of bits, encoded as arrays of little endian Numbers.
+ *
+ * @description
+ * <p>
+ * Some crypto functions need little endian input; these functions provide
+ * the functions to convert and handle them.
+ * </p>
+ *
+ * <p>
+ * There are two ways converting bit arrays from and to little-endian:
+ * one just reverses all bits in a word, and the other only reverses the
+ * bytes (and can only be used with byte aligned input).
+ * </p>
+ *
+ * <p>
+ * Uses the same magic "bit length" encoding in the last word as sjcl.bitArray.
+ * </p>
+ */
+sjcl.bitArrayLE = (function() {
+  /** Make a partial word for a bit array.
+   * @function
+   * @name sjcl.bitArrayLE.partial
+   * @param {Number} len           The number of bits in the word (1-32).
+   * @param {Number} x             The bits.
+   * @return {Number}              The partial word.
+   */
+  function partial(len, x) {
+    if (len === 32) { return x|0; }
+    var mask = (1 << len) - 1;
+    x = mask & x;
+    return x + len * 0x10000000000;
+  }
+
+  /** Get the number of bits used by a partial word.
+   * @function
+   * @name sjcl.bitArrayLE.getPartial
+   * @param {Number} x The partial word.
+   * @return {Number}  The number of bits used by the partial word.
+   */
+  function getPartial(x) {
+    return Math.round(x/0x10000000000) || 32;
+  }
+
+  /** Find the length of an array of bits.
+   * @function
+   * @name sjcl.bitArrayLE.bitLength
+   * @param {sjcl.bitArrayLE} a The array.
+   * @return {Number}           The length of a, in bits.
+   */
+  function bitLength(a) {
+    var l = a.length, x;
+    if (l === 0) { return 0; }
+    x = a[l - 1];
+    return (l-1) * 32 + getPartial(x);
+  }
+
+  /** Sets partial length on last word.
+   * @function
+   * @name sjcl.bitArrayLE._clampLastM
+   * @param {sjcl.bitArrayLE} a The array to modify.
+   * @param {Number} len        The partial length to set (0-32; 0 is intepreted as 32).
+   * @return {sjcl.bitArrayLE}  The modified array.
+   * @private
+   */
+  function _clampLastM(a, len) {
+    len &= 31;
+    if (a.length > 0 && len > 0) {
+      a[a.length-1] = partial(len, a[a.length-1]);
+    }
+    return a;
+  }
+
+  /** Truncate an array inplace.
+   * @function
+   * @name sjcl.bitArrayLE.clampM
+   * @param {sjcl.bitArrayLE} a The array.
+   * @param {Number} len        The length to truncate to, in bits.
+   * @return {sjcl.bitArrayLE}  The array, truncated to len bits.
+   */
+  function clampM(a, len) {
+    if (a.length * 32 <= len) { return a; }
+    a.splice(Math.ceil(len / 32), a.length);
+    return _clampLastM(a, len & 31);
+  }
+
+  /** Shift an array left inplace. Doesn't set any partial information.
+   * @function
+   * @name sjcl.bitArrayLE._shiftLeftM
+   * @param {sjcl.bitArrayLE} a  The array to shift.
+   * @param {Number} shift       The number of bits to shift (0-31)
+   * @param {Number} start       Array index of first word to shift in array
+   * @param {Number} end         Array index of the word after the last word to shift
+   * @param {Number} [carry=0]   A word to shift in from the right (using "shift" high bits)
+   * @return {Number}            The word shifted out on the left (using "shift" high bits)
+   * @private
+   */
+  function _shiftLeftM(a, shiftL, start, end, carry) {
+    var i, t, shiftR;
+    if (0 === shiftL) {
+      return 0;
+    }
+    shiftR = 32 - shiftL;
+    for (i = end; i-- > start; ) {
+      t = a[i];
+      // shifting array left means shifting bits right in a word
+      a[i] = (t >>> shiftL) | carry;
+      carry = t << shiftR;
+    }
+    return carry;
+  }
+
+  /** Shift an array left inplace, dropping the first shift bits
+   * @function
+   * @name sjcl.bitArrayLE.shiftLeftM
+   * @param {sjcl.bitArrayLE} a The array to shift.
+   * @param {Number} shift      The number of bits to shift
+   * @return {sjcl.bitArrayLE}  The shifted array.
+   */
+  function shiftLeftM(a, shiftL) {
+    if (shiftL >= 32) {
+      a.splice(0, Math.floor(shiftL / 32));
+    }
+    shiftL &= 31;
+    if (0 === a.length || 0 === shiftL) {
+      return a;
+    }
+    var last = getPartial(a[a.length-1]);
+    _shiftLeftM(a, shiftL, 0, a.length);
+    last = last - shiftL;
+    if (last <= 0) {
+      a.pop();
+    }
+    return _clampLastM(a, last & 31);
+  }
+
+  /** bit reverse all words in an array inplace
+   * (does not handle partial words)
+   * @function
+   * @name sjcl.bitArrayLE.bitReverseM
+   * @param {sjcl.bitArray} a    The word array
+   * @return {sjcl.bitArray}     bit reversed array
+   */
+  function bitReverseM(a) {
+    var i, j, v, w;
+    for (i = 0; i < a.length; ++i) {
+      v = a[i];
+      w = 0;
+      for (j = 0; j < 32; ++j) {
+        w = (w << 1) | (v & 1);
+        v >>>= 1;
+      }
+      a[i] = w;
+    }
+    return a;
+  }
+
+  /** @scope sjcl.bitArrayLE */
+  return {
+    /** Array slices in units of bits.
+     * @param {sjcl.bitArrayLE} a The array to slice.
+     * @param {Number} bstart     The offset to the start of the slice, in bits.
+     * @param {Number} [bend]     The offset to the end of the slice, in bits.
+     *                            If this is undefined, slice until the end of the array.
+     * @return {sjcl.bitArrayLE}  The requested slice.
+     */
+    bitSlice: function (a, bstart, bend) {
+      // only slice the part of the input that is actually needed
+      a = a.slice(bstart/32, undefined === bend ? a.length : Math.ceil(bend / 32));
+      shiftLeftM(a, bstart & 31);
+      return (undefined === bend ? a : clampM(a, bend - bstart));
+    },
+
+    /** Concatenate two bit arrays.
+     * @param {sjcl.bitArrayLE} a1 The first array.
+     * @param {sjcl.bitArrayLE} a2 The second array.
+     * @return {sjcl.bitArrayLE}   The concatenation of a1 and a2.
+     */
+    concat: function (a1, a2) {
+      if (a1.length === 0 || a2.length === 0) {
+        return a1.concat(a2);
+      }
+
+      var a = a1.concat(a2), last1 = a1[a1.length-1], last2 = a2[a2.length-1],
+        shift = 32 - getPartial(last1),
+        last = getPartial(last2) - shift;
+      // shift second part to the left by what is missing in last1, add carry at the end of the first part */
+      a[a1.length-1] |= _shiftLeftM(a, shift, a1.length, a.length);
+      // set partial length on last byte. if < 0 all bits were shifted out of the last word, drop it
+      if (last <= 0) {
+        a.pop();
+      }
+      return _clampLastM(a, last & 31);
+    },
+
+    /** Truncate an array.
+     * @param {sjcl.bitArrayLE} a The array.
+     * @param {Number} len        The length to truncate to, in bits.
+     * @return {sjcl.bitArrayLE}  A new array, truncated to len bits.
+     */
+    clamp: function (a, len) {
+      a = a.slice(0, Math.ceil(len / 32));
+      return _clampLastM(a, len & 31);
+    },
+
+    /** Compare two arrays for equality in a predictable amount of time.
+     * @param {sjcl.bitArrayLE} a The first array.
+     * @param {sjcl.bitArrayLE} b The second array.
+     * @return {boolean}          true if a == b; false otherwise.
+     */
+    equal: function (a, b) {
+      if (bitLength(a) !== bitLength(b)) {
+        return false;
+      }
+      var x = 0, i;
+      for (i=0; i<a.length; i++) {
+        x |= a[i]^b[i];
+      }
+      return (x === 0);
+    },
+
+    partial: partial,
+    getPartial: getPartial,
+    bitLength: bitLength,
+    _clampLastM: _clampLastM,
+    clampM: clampM,
+    _shiftLeftM: _shiftLeftM,
+    shiftLeftM: shiftLeftM,
+    bitReverseM: bitReverseM,
+
+    /** convert big endian bit array to little endian by byteswapping all
+     * words. the bytes stored in the input are reinterpreted as little endian
+     * bytes. a partial byte at the end gets realigned (shifted).
+     * @param {sjcl.bitArray} a   The array to convert
+     * @return {sjcl.bitArrayLE}  The converted array
+     */
+    fromBitArrayByteSwap: function(a) {
+      if (0 === a.length) {
+        return [];
+      }
+      var i = a.length - 1, lastLen = sjcl.bitArray.getPartial(a[i]), mask;
+      a = sjcl.bitArray.byteswapM(a.slice(0));
+      if (lastLen & 0x7) {
+        // realign last byte
+        mask = 0xff << (lastLen & 0x18);
+        a[i] = (a[i] & ~mask) | (mask & ( (a[i] & mask) >>> (8 - lastLen & 0x7) ));
+      }
+      return _clampLastM(a, lastLen);
+    },
+
+    /** convert little endian bit array to big endian by byteswapping all
+     * words. the bytes stored in the input are reinterpreted as big endian
+     * bytes. a partial byte at the end gets realigned (shifted).
+     * @param {sjcl.bitArrayLE} a  The array to convert
+     * @return {sjcl.bitArray}     The converted array
+     */
+    toBitArrayByteSwap: function(a) {
+      if (0 === a.length) {
+        return [];
+      }
+      var i = a.length - 1, lastLen = getPartial(a[i]), mask;
+      a = sjcl.bitArray.byteswapM(a.slice(0));
+      if (lastLen & 0x7) {
+        // realign last byte
+        mask = 0xff << (24 - (lastLen & 0x18));
+        a[i] = (a[i] & ~mask) | (mask & ( (a[i] & mask) << (8 - lastLen & 0x7) ));
+      }
+
+      // don't depend on sjcl.bitArray._clampLastM yet
+      // return sjcl.bitArray._clampLastM(a, lastLen);
+      a[i] = sjcl.bitArray.partial(lastLen, a[i], 1);
+      return a;
+    },
+
+    /** convert big endian bit array to little endian.
+     * simple reverses the bits in all words.
+     * @param {sjcl.bitArray} a   The array to convert
+     * @return {sjcl.bitArrayLE}  The converted array
+     */
+    fromBitArrayBitReverse: function(a) {
+      if (0 === a.length) {
+        return [];
+      }
+      var lastLen = sjcl.bitArray.getPartial(a[a.length-1]);
+      return _clampLastM(bitReverseM(a.slice(0)), lastLen);
+    },
+
+    /** convert little endian bit array to big endian.
+     * simple reverses the bits in all words.
+     * @param {sjcl.bitArrayLE} a  The array to convert
+     * @return {sjcl.bitArray}     The converted array
+     */
+    toBitArrayBitReverse: function(a) {
+      if (0 === a.length) {
+        return [];
+      }
+      var lastLen = getPartial(a[a.length-1]);
+      // don't depend on sjcl.bitArray._clampLastM yet
+      // return sjcl.bitArray._clampLastM(bitReverseM(a.slice(0)), lastLen);
+      a = bitReverseM(a.slice(0));
+      a[a.length-1] = sjcl.bitArray.partial(lastLen, a[a.length-1], 1);
+      return a;
+    }
+  };
+}());

--- a/core/keccak_f.js
+++ b/core/keccak_f.js
@@ -1,0 +1,417 @@
+/** @fileOverview Keccak-f permutations
+ *
+ * @author Stefan Bühler
+ */
+
+/** @ignore */
+sjcl.hash.keccak_f = (function() {
+  // Keccak 1600: each lane as [low,high] little endian (32-bit) words. state[2*(5*y+x)] = low, state[2*(5*y+x)+1] = high
+  // Keccak <= 800: each lane as little endian word in state[5*y+x]
+
+  var RC, rhoBY, piMAP;
+
+  function precompute() {
+    var p, rc, i, j, x, y;
+    // RC
+    RC = [];
+    p = 1; // p = X^0 = 1
+    for (i = 0; i < 24; ++i) {
+      rc = 0;
+      for (j = 0; j < 6; ++j) {
+        rc ^= (p & 0x1) << ((1 << j) - 1); // (p mod X) << (2^j - 1)
+        if (0x100 & (p <<= 1)) { p ^= 0x171; } // p := (p * X) mod X^8 + X^6 + X^5 + X^4 + 1
+      }
+      RC[i] = [rc,p << 31]; // 31 = (2^6-1) - 32: high word
+      if (0x100 & (p <<= 1)) { p ^= 0x171; }
+    }
+    // rhoBY
+    rhoBY = [0];
+    x = 1; y = 0;
+    for (i = 0; i < 24; ++i) {
+      rhoBY[x+5*y] = (((i+1)*(i+2))/2) & 63;
+      y = (2*x+3*y)%5; x = (x+2*y)%5;
+    }
+    // piMAP
+    piMAP = [];
+    for (x = 0; x < 5; ++x) {
+      for (y = 0; y < 5; ++y) {
+        piMAP[x+5*y] = y + 5*((2*x+3*y)%5);
+      }
+    }
+  }
+
+/*
+  // debug helpers to print internal states similar to official implementation
+  function w32h(v) {
+    var m = 4294967296;
+    return ("00000000" + (((v ^ 0) + m) % m).toString(16)).slice(-8);
+  }
+  function print1600(msg, state) {
+    var lines = [], line,x,y;
+    for (y = 0; y < 50; y+=10) {
+      line = [];
+      for (x = 0; x < 10; x+=2) {
+        line.push(w32h(state[x+y+1]) + w32h(state[x+y]));
+      }
+      lines.push(line.join(' ') + "\n");
+    }
+    console.log(msg + ":\n" + lines.join(''));
+  }
+  function print(msg, state, w) {
+    var lines = [], line,x,y;
+    w = (w + 3) >>> 2;
+    for (y = 0; y < 25; y+=5) {
+      line = [];
+      for (x = 0; x < 5; ++x) {
+        line.push(w32h(state[x+y]).slice(-w));
+      }
+      lines.push(line.join(' ') + "\n");
+    }
+    console.log(msg + ":\n" + lines.join(''));
+  }
+*/
+
+/*
+  function theta1600(state, buf) {
+    var ccL,ccH,ddL,ddH,x,y,x1,x4;
+    for (x = 0; x < 10; x+=2) {
+      ccL = state[x]; ccH = state[x+1];
+      for (y = 10; y < 50; y+=10) {
+        ccL ^= state[x+y]; ccH ^= state[x+y+1];
+      }
+      buf[x] = ccL; buf[x+1] = ccH;
+    }
+    for (x = 0; x < 10; x+=2) {
+      x1 = (x+2) % 10; x4 = (x+8) % 10;
+      ddL = buf[x1]; ddH = buf[x1+1];
+      ccL = buf[x4] ^ (ddL << 1 | ddH >>> 31)
+      ccH = buf[x4+1] ^ (ddH << 1 | ddL >>> 31);
+      for(y = 0; y < 50; y+=10) {
+        state[x+y] ^= ccL;
+        state[x+y+1] ^= ccH;
+      }
+    }
+  }
+  function rotate1600(state, laneLo, by) {
+    var laneHi=laneLo+1,lo, hi, t;
+    if ((by &= 63)) {
+      lo = state[laneLo]; hi = state[laneHi];
+      if (by >= 32) { t = lo; lo = hi; hi = t; }
+      if ((by &= 31)) {
+        state[laneLo] = lo << by | hi >>> (32-by);
+        state[laneHi] = hi << by | lo >>> (32-by);
+      } else {
+        state[laneLo] = lo; state[laneHi] = hi;
+      }
+    }
+  }
+  function rho1600(state) {
+    var k;
+    for (k = 0; k < 25; ++k) rotate1600(state, 2*k, rhoBY[k]);
+  }
+  function pi1600(to, from) {
+    var k, t;
+    for (k = 0; k < 25; ++k) {
+      t = piMAP[k];
+      to[2*t]   = from[2*k];
+      to[2*t+1] = from[2*k+1];
+    }
+  }
+  function chi1600(to, from) {
+    var x,x1,x2,y;
+    for (x = 0; x < 10; x+=2) {
+      x1 = (x+2)%10; x2 = (x+4)%10;
+      for (y = 0; y < 50; y+=10) {
+        to[x+y]   = from[x+y]   ^ (~from[x1+y]   & from[x2+y]);
+        to[x+y+1] = from[x+y+1] ^ (~from[x1+y+1] & from[x2+y+1]);
+      }
+    }
+  }
+  function iota1600(state, round) {
+    state[0] ^= RC[round][0];
+    state[1] ^= RC[round][1];
+  }
+  function keccak_f1600(state) {
+    var i;
+    var buf = state.slice();
+    //print1600("input", state);
+    for (i = 0; i < 24; ++i) {
+      theta1600(state, buf);
+      //print1600("round " + i + " after theta", state);
+      rho1600(state);
+      //print1600("round " + i + " after rho", state);
+      pi1600(buf, state);
+      //print1600("round " + i + " after pi", state);
+      chi1600(state, buf);
+      //print1600("round " + i + " after chi", state);
+      iota1600(state, i);
+      //print1600("round " + i + " after iota", state);
+    }
+    return state;
+  }
+*/
+
+  /** Run the Keccak-f transformation on a 1600-bit state
+   * @name sjcl.hash.keccak_f1600
+   * @param {sjcl.bitArrayLE} a  The state to transform (gets modified)
+   * @return {sjcl.bitArrayLE}   The modified state
+   */
+  function keccak_f1600(state) {
+    // manually inlined
+    var i,
+      buf = state.slice(),
+      ccL,ccH,ddL,ddH,x,y,x1,x2,x4,
+      k,lo, hi, t, by;
+    if (!RC) { precompute(); }
+    for (i = 0; i < 24; ++i) {
+      // theta
+      for (x = 0; x < 10; x+=2) {
+        ccL = state[x]; ccH = state[x+1];
+        for (y = 10; y < 50; y+=10) {
+          ccL ^= state[x+y]; ccH ^= state[x+y+1];
+        }
+        buf[x] = ccL; buf[x+1] = ccH;
+      }
+      for (x = 0; x < 10; x+=2) {
+        x1 = (x+2) % 10; x4 = (x+8) % 10;
+        ddL = buf[x1]; ddH = buf[x1+1];
+        ccL = buf[x4] ^ (ddL << 1 | ddH >>> 31);
+        ccH = buf[x4+1] ^ (ddH << 1 | ddL >>> 31);
+        for(y = 0; y < 50; y+=10) {
+          state[x+y] ^= ccL;
+          state[x+y+1] ^= ccH;
+        }
+      }
+      // rhopi (state -> buf)
+      for (k = 0; k < 25; ++k) {
+        by = rhoBY[k];
+        lo = state[2*k]; hi = state[2*k+1];
+        if (by >= 32) { t = lo; lo = hi; hi = t; }
+        t = piMAP[k];
+        if ((by &= 31)) {
+          buf[2*t] = lo << by | hi >>> (32-by);
+          buf[2*t+1] = hi << by | lo >>> (32-by);
+        } else {
+          buf[2*t] = lo; buf[2*t+1] = hi;
+        }
+      }
+      // chi (buf -> state)
+      for (x = 0; x < 10; x+=2) {
+        x1 = (x+2)%10; x2 = (x+4)%10;
+        for (y = 0; y < 50; y+=10) {
+          state[x+y]   = buf[x+y]   ^ (~buf[x1+y]   & buf[x2+y]);
+          state[x+y+1] = buf[x+y+1] ^ (~buf[x1+y+1] & buf[x2+y+1]);
+        }
+      }
+      // iota
+      state[0] ^= RC[i][0];
+      state[1] ^= RC[i][1];
+    }
+    return state;
+  }
+  keccak_f1600.width = 1600;
+  sjcl.hash.keccak_f1600 = keccak_f1600;
+
+/*
+  function keccak_f_gen(l) {
+    var w = 1 << l, mask = w === 32 ? ~0 : (1 << w) - 1, rounds = 12 + 2*l;
+
+    function rotate(x, by) {
+      if (!(by %= w)) return x;
+      x &= mask;
+      return ((x << by) | (x >>> (w - by))) & mask;
+    }
+
+    function theta(state) {
+      var cc,c=[], x, y;
+      for (x = 0; x < 5; ++x) {
+        cc = state[x];
+        for (y = 5; y < 25; y+=5) {
+          cc ^= state[x + y];
+        }
+        c[x] = cc;
+      }
+      for (x = 0; x < 5; ++x) {
+        cc = c[(x+4)%5] ^ rotate(c[(x+1)%5], 1);
+        for(y = 0; y < 25; y+=5) {
+          state[x + y] ^= cc;
+        }
+      }
+    }
+    function rho(state) {
+      var k;
+      for (k = 0; k < 25; ++k) state[k] = rotate(state[k], rhoBY[k]);
+    }
+    function pi(state) {
+      var s = state.slice(), k;
+      for (k = 0; k < 25; ++k) state[piMAP[k]] = s[k];
+    }
+    function chi(state) {
+      var s = state.slice(), x,x1,x2,y;
+      for (x = 0; x < 5; ++x) {
+        x1 = (x+1)%5; x2 = (x+2)%5;
+        for (y = 0; y < 25; y+=5) {
+          state[x+y] = s[x+y] ^ (~s[x1+y] & s[x2+y]);
+        }
+      }
+    }
+    function iota(state, round) {
+      state[0] ^= RC[round][0] & mask;
+    }
+    function read(data) {
+      var i, j, p, v, l = 32 / w, state = [];
+      for (i = 0, p = 0; i < 25; ++p) {
+        v = data[p];
+        for (j = 0; i < 25 && j < l; ++j, ++i) {
+          state[i] = v & mask; v >>>= w;
+        }
+      }
+      return state;
+    }
+    function write(data, state) {
+      var i, j, p, v, l = 32 / w;
+      for (i = 0, p = 0; i < 25; ++p) {
+        v = 0;
+        for (j = 0; j < l; ++j, ++i) {
+          v = (v >>> w) | ((state[i] & mask) << (32 - w));
+        }
+        data[p] = v;
+      }
+    }
+    function keccak_f(data) {
+      var state, i;
+      state = read(data);
+      // print("input", state, w);
+      for (i = 0; i < rounds; ++i) {
+        theta(state);
+        // print("round " + i + " after theta", state, w);
+        rho(state);
+        // print("round " + i + " after rho", state, w);
+        pi(state);
+        // print("round " + i + " after pi", state, w);
+        chi(state);
+        // print("round " + i + " after chi", state, w);
+        iota(state, i);
+        // print("round " + i + " after iota", state, w);
+      }
+      write(data, state);
+      return data;
+    }
+    keccak_f.width = 25 * w;
+    return keccak_f;
+  }
+*/
+
+  /** Return the Keccak-f transformation for a state with (25 * 2^l) bits, for l <= 5 (=> w = 2^l <= 32, width <= 800)
+   * (the 1600 bit state has an explicit function, as for l <= 5 only one word per lane is needed)
+   * @return {function} the Keccak-f transformation, taking a {@link sjcl.bitArrayLE} to operate on, and returning the modified state
+   */
+  function keccak_f_gen(l) {
+    var w = 1 << l, mask = w === 32 ? ~0 : (1 << w) - 1, rounds = 12 + 2*l;
+
+    function rotate(x, by) {
+      if (!(by %= w)) { return x; }
+      return ((x << by) | (x >>> (w - by))) & mask;
+    }
+
+    function read(data) {
+      var i, j, p, v, l = 32 / w, state = [];
+      for (i = 0, p = 0; i < 25; ++p) {
+        v = data[p];
+        for (j = 0; i < 25 && j < l; ++j, ++i) {
+          state[i] = v & mask; v >>>= w;
+        }
+      }
+      return state;
+    }
+    function write(data, state) {
+      var i, j, p, v, l = 32 / w;
+      for (i = 0, p = 0; i < 25; ++p) {
+        v = 0;
+        for (j = 0; j < l; ++j, ++i) {
+          v = (v >>> w) | ((state[i] & mask) << (32 - w));
+        }
+        data[p] = v;
+      }
+    }
+
+    /** Run the Keccak-f transformation
+     * @param {sjcl.bitArrayLE} a  The state to transform (gets modified)
+     * @return {sjcl.bitArrayLE}   The modified state
+     */
+    function keccak_f(data) {
+      var state, i, buf,
+        cc, x, y, k, x1, x2;
+      if (!RC) { precompute(); }
+
+      state = w === 32 ? data : read(data);
+      buf = state.slice();
+      for (i = 0; i < rounds; ++i) {
+        // theta
+        for (x = 0; x < 5; ++x) {
+          cc = state[x];
+          for (y = 5; y < 25; y+=5) {
+            cc ^= state[x + y];
+          }
+          buf[x] = cc;
+        }
+        for (x = 0; x < 5; ++x) {
+          cc = buf[(x+1)%5];
+          cc = ((cc << 1) | (cc >>> (w - 1))) & mask;
+          cc ^= buf[(x+4)%5];
+          for(y = 0; y < 25; y+=5) {
+            state[x + y] ^= cc;
+          }
+        }
+        // rho + pi (state -> buf)
+        for (k = 0; k < 25; ++k) {
+          buf[piMAP[k]] = rotate(state[k], rhoBY[k]);
+        }
+        // chi (buf -> state)
+        for (x = 0; x < 5; ++x) {
+          x1 = (x+1)%5; x2 = (x+2)%5;
+          for (y = 0; y < 25; y+=5) {
+            state[x+y] = buf[x+y] ^ (~buf[x1+y] & buf[x2+y]);
+          }
+        }
+        // iota
+        state[0] ^= RC[i][0] & mask;
+      }
+      if (w !== 32) {
+        write(data, state);
+      }
+      return data;
+    }
+    keccak_f.width = 25 * w;
+    sjcl.hash['keccak_f' + keccak_f.width] = keccak_f;
+    return keccak_f;
+  }
+
+  /** Create a Keccak-f transformation function for a specified bit width.
+   * @function
+   * @name sjcl.hash.keccak_f
+   * @param {Number} bitwidth   Anything in [25,50,100,200,400,800,1600];
+   *                            bitwidth = 25*2^l for 0 <= l <= 6
+   * @return {function}         The transformation function: taking, modifying
+   *                            and returning a {@link sjcl.bitArrayLE}
+   */
+  function keccak_f_get(b) {
+    var f = sjcl.hash['keccak_f' + b], l;
+    if (f) {
+      return f;
+    }
+    l = [25,50,100,200,400,800,1600].indexOf(b);
+    if (l < 0) {
+      throw new sjcl.exception.invalid("invalid keccak bit width");
+    }
+    if (b === 1600) {
+      return keccak_f1600;
+    }
+    if ('undefined' !== typeof keccak_f_gen) {
+      return keccak_f_gen(l);
+    }
+    throw new sjcl.exception.invalid("keccak bit width < 1600 not supported");
+  }
+
+  return keccak_f_get;
+}());

--- a/core/sha3.js
+++ b/core/sha3.js
@@ -1,0 +1,62 @@
+/** @fileOverview SHA3 functions
+ *
+ * @author Stefan Bühler
+ */
+
+/** Create a Keccak sponge class with given parameters. Uses
+ * {@link sjcl.hash.sponge.makeClass} and adds a width and a capacity
+ * property.
+ * @param {Number} capacity          The capacity of the sponge
+ * @param {Number} [out=2*capacity]  The output bit width
+ * @param {Number} [width=1600]      Bitwidth for {@link sjcl.hash.keccak_f}
+ * @param {function} [pad]           Custom padding function (defaults to
+ *     {@link sjcl.hash.sponge.pad_101})
+ * @return {function} Sponge class
+ */
+sjcl.hash.keccak = function (capacity, out, width, pad) {
+  var rate, keccak_f, sponge = sjcl.hash.sponge, constr;
+  out = out || (capacity >>> 1);
+  capacity = capacity || 2 * out;
+  width = width || 1600;
+  rate = width - capacity;
+  keccak_f = sjcl.hash.keccak_f(width);
+  pad = pad || sponge.pad_101;
+
+  constr = sponge.makeClass(keccak_f, pad, rate, out);
+  // set additional properties
+  constr.width = width;
+  constr.capacity = capacity;
+  return constr;
+};
+
+// common keccak variants used for SHA3, SHAKE128 and SHAKE256
+/** Keccak[256] sponge (= sjcl.hash.keccak(256)) */
+sjcl.hash.keccak_256 = sjcl.hash.keccak(256);
+/** Keccak[448] sponge (= sjcl.hash.keccak(448)) */
+sjcl.hash.keccak_448 = sjcl.hash.keccak(448);
+/** Keccak[512] sponge (= sjcl.hash.keccak(512)) */
+sjcl.hash.keccak_512 = sjcl.hash.keccak(512);
+/** Keccak[768] sponge (= sjcl.hash.keccak(768)) */
+sjcl.hash.keccak_768 = sjcl.hash.keccak(768);
+/** Keccak[1024] sponge (= sjcl.hash.keccak(1024)) */
+sjcl.hash.keccak_1024 = sjcl.hash.keccak(1024);
+
+/* domain pad with bits "01" which are encoded as 10b = 2 (little endian) */
+sjcl.hash._sha3_domain_pad = sjcl.hash.sponge.pad_domain_101([sjcl.bitArrayLE.partial(2, 2)]);
+
+/** SHA3-224 sponge (using Keccak[448] {@link sjcl.hash.keccak_448} with domain separation) */
+sjcl.hash.sha3_224 = sjcl.hash.keccak(448, 0, 0, sjcl.hash._sha3_domain_pad);
+/** SHA3-256 sponge (using Keccak[512] {@link sjcl.hash.keccak_512} with domain separation) */
+sjcl.hash.sha3_256 = sjcl.hash.keccak(512, 0, 0, sjcl.hash._sha3_domain_pad);
+/** SHA3-384 sponge (using Keccak[768] {@link sjcl.hash.keccak_768} with domain separation) */
+sjcl.hash.sha3_384 = sjcl.hash.keccak(768, 0, 0, sjcl.hash._sha3_domain_pad);
+/** SHA3-512 sponge (using Keccak[1024] {@link sjcl.hash.keccak_1024} with domain separation) */
+sjcl.hash.sha3_512 = sjcl.hash.keccak(1024, 0, 0, sjcl.hash._sha3_domain_pad);
+
+/* domain pad with bits "1111" which are encoded as 1111b = 15 (little endian) */
+sjcl.hash._sha3_xof_domain_pad = sjcl.hash.sponge.pad_domain_101([sjcl.bitArrayLE.partial(4, 0xf)]);
+
+/** SHAKE128 sponge (using Keccak[256] {@link sjcl.hash.keccak_256} with domain separation) */
+sjcl.hash.shake128 = sjcl.hash.keccak(256, 0, 0, sjcl.hash._sha3_xof_domain_pad);
+/** SHAKE256 sponge (using Keccak[512] {@link sjcl.hash.keccak_512} with domain separation) */
+sjcl.hash.shake256 = sjcl.hash.keccak(512, 0, 0, sjcl.hash._sha3_xof_domain_pad);

--- a/core/sponge.js
+++ b/core/sponge.js
@@ -1,0 +1,180 @@
+/** @fileOverview Sponge implementation for Keccak/SHA3/SHAKE
+ *
+ * @author Stefan Bühler
+ */
+
+/** Context for a Sponge operations.
+ * @constructor
+ * @param {function} f       The transformation function to run on a 
+ *     {@link sjcl.bitArrayLE} state with f.width bits (rounded up to next
+ *     multiple of 32).
+ * @param {function} pad     The padding function that pads a
+ *     {@link sjcl.bitArrayLE} buffer to a number of bits on finalize.
+ * @param {Number} rate      The bit rate; number of bits to read/write per
+ *     round of transformation
+ * @param {Number} [outlen]  The number of bits to output. Can be specified in
+ *     call to {@link #finalize} too.
+ */
+sjcl.hash.sponge = function(f, pad, rate, outlen) {
+  this._f = f;
+  this._pad = pad;
+  this._r = rate;
+  this._l = outlen;
+  this._buffer = false;
+
+  var s = [], i;
+  for (i = 0; i < f.width; i += 32) {
+    s.push(0);
+  }
+  this._state = s;
+};
+
+/** "10*1" padding
+ * @param {sjcl.bitArrayLE} data  The data to pad
+ * @param {Number} r              The length to pad to a multiple of.
+ * @param {sjcl.bitArrayLE}       The padded message
+ */
+sjcl.hash.sponge.pad_101 = function(msg, r) {
+  var baLE = sjcl.bitArrayLE, len = baLE.bitLength(msg), dstLen, bit;
+  msg = msg.slice(0);
+  /* round len + 2 up to multiple of r */
+  dstLen = len + 1 + r;
+  dstLen -= dstLen % r;
+  /* append "1" */
+  bit = len % 32;
+  if (bit) {
+    msg[msg.length-1] |= 1 << bit;
+  } else {
+    msg.push(1);
+  }
+  len += (32 - bit);
+  for (; len < dstLen; len += 32) {
+    msg.push(0);
+  }
+  msg[msg.length-1] |= 1 << (r-1);
+  baLE.clampM(msg, dstLen);
+  return msg;
+};
+
+/** Domain + "10*1" padding; appends a domain to the message before
+ * {@link sjcl.hash.sponge.pad_101} padding.
+ * @param {sjcl.bitArrayLE} domain  The domain to pad with
+ * @return {function}               A padding function
+ */
+sjcl.hash.sponge.pad_domain_101 = function(domain) {
+  var baLE = sjcl.bitArrayLE, pad_101 = sjcl.hash.sponge.pad_101;
+  return function(msg, r) {
+    return pad_101(baLE.concat(msg, domain), r);
+  };
+};
+
+/** Absorb data in rounds, store remainder in this._buffer
+ * @this {sjcl.hash.sponge}
+ * @param {sjcl.bitArrayLE} data  The data to hash in little endian words.
+ */
+sjcl.hash.sponge.prototype._absorb = function _absorb(data) {
+  var baLE = sjcl.bitArrayLE, i, j, p, l, r = this._r, s = this._state, f = this._f;
+  for (i = 0, l = baLE.bitLength(data); i + r <= l; i += r) {
+    p = baLE.bitSlice(data, i, i + r);
+    for (j = 0; j < p.length; ++j) {
+      s[j] ^= p[j];
+    }
+    f(s);
+  }
+  if (i < l) {
+    this._buffer = baLE.bitSlice(data, i, l);
+  } else {
+    this._buffer = false;
+  }
+};
+
+/** Input several words to hash.
+ * @this {sjcl.hash.sponge}
+ * @param {sjcl.bitArrayLE} data  The data to hash in little endian words.
+ * @return {sjcl.hash.sponge} this
+ */
+sjcl.hash.sponge.prototype.updateLE = function updateLE(data) {
+  if (this._buffer) {
+    data = sjcl.bitArrayLE.concat(this._buffer, data);
+    this._buffer = false;
+  }
+  this._absorb(data);
+  return this;
+};
+
+/** Input several words to hash.
+ * @this {sjcl.hash.sponge}
+ * @param {sjcl.bitArray|String} data the data to hash.
+ * @return {sjcl.hash.sponge} this
+ */
+sjcl.hash.sponge.prototype.update = function update(data) {
+  if (typeof data === "string") {
+    data = sjcl.codec.utf8String.toBits(data);
+  }
+  data = sjcl.bitArrayLE.fromBitArrayByteSwap(data);
+  return this.updateLE(data);
+};
+
+/** Complete hashing and output the hash value.
+ * @this {sjcl.hash.sponge}
+ * @param {Number} [outlen]   bit-length of output to generate
+ * @return {sjcl.bitArrayLE}  The hash value.
+ */
+sjcl.hash.sponge.prototype.finalizeLE = function finalizeLE(outlen) {
+  var baLE = sjcl.bitArrayLE, j, r = this._r, s, f = this._f, z,
+    data = this._pad(this._buffer || [], r);
+  this._buffer = false;
+  outlen = outlen || this._l;
+
+  this._absorb(data);
+  if (this._buffer) {
+    throw new sjcl.exception.invalid("sponge padding misaligned");
+  }
+
+  s = this._state;
+  this._state = null; // undefined after finalize
+  z = baLE.clamp(s, r);
+  for (j = r; j < outlen; j += r) {
+    f(s);
+    z = baLE.concat(z, baLE.clamp(s, r));
+  }
+  return baLE.clamp(z, outlen);
+};
+
+/** Complete hashing and output the hash value (converted from
+ * {@link sjcl.hash.sponge#finalizeLE} with
+ * {@link sjcl.bitArrayLE.toBitArrayByteSwap})
+ * @this {sjcl.hash.sponge}
+ * @param {Number} [outlen]  bit-length of output to generate (should be
+ *     a multiple of 8)
+ * @return {sjcl.bitArray}   The hash value
+ */
+sjcl.hash.sponge.prototype.finalize = function finalize(outlen) {
+  return sjcl.bitArrayLE.toBitArrayByteSwap(this.finalizeLE(outlen));
+};
+
+/** Create a class for a Sponge operations; returns an function object with
+ * the following properties: "rate": the rate parameter and "hash": a shortcut
+ * function (data, outlen) { return class().update(data).finalize(outlen); };
+ * calling the returned function returns a {@link sjcl.hash.sponge} object.
+ *
+ * @param {function} f       The transformation function to run on a 
+ *     {@link sjcl.bitArrayLE} state with f.width bits (rounded up to next
+ *     multiple of 32).
+ * @param {function} pad     The padding function that pads a
+ *     {@link sjcl.bitArrayLE} buffer to a number of bits on finalize.
+ * @param {Number} rate      The bit rate; number of bits to read/write per
+ *     round of transformation
+ * @param {Number} [outlen]  The number of bits to output. Can be specified in
+ *     call to {@link #finalize} too.
+ */
+sjcl.hash.sponge.makeClass = function(f, pad, rate, outlen) {
+  function constr() {
+    return new sjcl.hash.sponge(f, pad, rate, outlen);
+  }
+  constr.rate = rate;
+  constr.hash = function(data, outlen) {
+    return constr().update(data).finalize(outlen);
+  };
+  return constr;
+};

--- a/test/bitArrayLE_test.js
+++ b/test/bitArrayLE_test.js
@@ -1,0 +1,123 @@
+(function() {
+
+  function word2hex(w) {
+    return "0x" + ((w|0)+0xF00000000000).toString(16).substr(4);
+  }
+
+  var b0 = sjcl.bitArrayLE.partial(1, 0);
+  var b1 = sjcl.bitArrayLE.partial(1, 1);
+  var b0_BE = sjcl.bitArray.partial(1, 0);
+  var b1_BE = sjcl.bitArray.partial(1, 1);
+
+  function concatbitsBE(s) {
+    var j, b, a = [];
+    for (j = 0; j < s.length; ++j) {
+      b = (s[j] === '1' ? b1_BE : b0_BE);
+      a = sjcl.bitArray.concat(a, [b]);
+    }
+    return a;
+  }
+  function concatbits(s) {
+    var j, b, a = [];
+    for (j = 0; j < s.length; ++j) {
+      b = (s[j] === '1' ? b1 : b0);
+      a = sjcl.bitArrayLE.concat(a, [b]);
+    }
+    return a;
+  }
+  function concatbits_reverse(s) {
+    var j, b, a = [];
+    for (j = s.length; j-- > 0; ) {
+      b = (s[j] === '1' ? b1 : b0);
+      a = sjcl.bitArrayLE.concat(a, [b]);
+    }
+    return a;
+  }
+
+
+  new sjcl.test.TestCase("bitArrayLE single bits", function (cb) {
+    if (!sjcl.bitArrayLE) {
+      this.unimplemented();
+      cb && cb();
+      return;
+    }
+
+    this.require((b0|0) === (0x00000000|0), "bitstring '0': " + word2hex(b0));
+    this.require((b1|0) === (0x00000001|0), "bitstring '1': " + word2hex(b1));
+
+    cb && cb();
+  });
+
+  new sjcl.test.TestCase("bitArrayLE concat small bitstrings", function (cb) {
+    if (!sjcl.bitArrayLE) {
+      this.unimplemented();
+      cb && cb();
+      return;
+    }
+
+    var i, kat = sjcl.test.vector.bitArray.bits, tv, a, b, a_BE, a2, a2_BE, bitlen, t;
+    for (i=0; i<kat.length; i++) {
+      tv = kat[i];
+      a = concatbits_reverse(tv[0]);
+      a2 = concatbits(tv[0]);
+      a2_BE = sjcl.bitArrayLE.toBitArrayBitReverse(a2);
+      a_BE = concatbitsBE(tv[0]);
+      bitlen = sjcl.bitArrayLE.bitLength(a);
+      t = "bitstring '" + tv[0] + "': ";
+      this.require(1 === a.length, t + "array length is 1: " + a.length);
+      this.require(bitlen === tv[0].length, t + "length " + bitlen + " matches input length " + tv[0].length);
+      b = sjcl.bitArrayLE.partial(tv[0].length, tv[1]);
+
+      this.require(a[0] === b, t + "array matches shifted number: " + word2hex(a[0]) + " == " + word2hex(b));
+
+      this.require(sjcl.bitArray.equal(a2_BE, a_BE), t + "toBitArrayBitReverse(" + word2hex(a2[0]) + ") matches big endian result: " + word2hex(a2_BE[0]) + " == " + word2hex(a_BE[0]));
+      a = sjcl.bitArrayLE.fromBitArrayBitReverse(a_BE);
+      this.require(sjcl.bitArrayLE.equal(a, a2), t + "fromBitArrayBitReverse(" + word2hex(a_BE[0]) + ") matches little endian result: " + word2hex(a[0]) + " == " + word2hex(a2[0]));
+    }
+
+    cb && cb();
+  });
+
+
+  new sjcl.test.TestCase("bitArrayLE concat, slicing, shifting and clamping", function (cb) {
+    if (!sjcl.bitArrayLE) {
+      this.unimplemented();
+      cb && cb();
+      return;
+    }
+
+    var i, j, kat = sjcl.test.vector.bitArray.slices, tv, a, a1, b, bitlen, t;
+    for (i=0; i<kat.length; i++) {
+      tv = kat[i];
+      a = [];
+      b = [];
+
+      bitlen = 0;
+      for (j=0; j<tv[0].length; j++) {
+        b[j] = concatbits(tv[0][j]);
+        a = sjcl.bitArrayLE.concat(a, b[j]);
+        bitlen += tv[0][j].length;
+      }
+
+      // shift last array entry and set partial length on it
+      a1 = tv[1]; a1 = a1.slice(0, a1.length);
+      bitlen &= 31;
+      if (0 !== bitlen) a1[a1.length-1] = sjcl.bitArray.partial(bitlen, a1[a1.length-1]);
+      a1 = sjcl.bitArrayLE.fromBitArrayBitReverse(a1);
+
+      this.require(sjcl.bitArrayLE.equal(a, a1), "concat: [" + a + "] == [" + a1 + "]");
+
+      t = 0;
+      for (j=0; j<tv[0].length; j++) {
+        bitlen = sjcl.bitArrayLE.bitLength(b[j]);
+        this.require(bitlen === tv[0][j].length, "bitstring length");
+        a1 = sjcl.bitArrayLE.bitSlice(a, t, t + bitlen);
+        this.require(sjcl.bitArrayLE.equal(b[j], a1), "slice after concat: [" + b[j] + "] == [" + a1 + "]");
+        t += bitlen;
+      }
+    }
+
+    cb && cb();
+  });
+
+})();

--- a/test/sha3_test.js
+++ b/test/sha3_test.js
@@ -1,0 +1,113 @@
+function test_keccak(capacity, rate) {
+  if (!rate) {
+    // the test cases are named after the output length...
+    // out := capacity / 2
+    var name = 'keccak_' + (capacity >> 1);
+    new sjcl.test.TestCase("Keccak[" + capacity + "] from Keccak KAT Keccak-" + (capacity >> 1), function (cb) {
+      if (!sjcl.hash.keccak) {
+        this.unimplemented();
+        cb && cb();
+        return;
+      }
+
+      var i, kat=sjcl.test.vector[name], p=0, f=0, keccak=sjcl.hash.keccak(capacity);
+      for (i=0; i<kat.length; i++) {
+        var data = sjcl.bitArray.clamp(sjcl.codec.hex.toBits(kat[i][1]), kat[i][0]);
+        var out = keccak.hash(data);
+        this.require(sjcl.bitArray.equal(out, sjcl.codec.hex.toBits(kat[i][2])), i+": "+sjcl.codec.hex.fromBits(out) + " != " + kat[i][2]);
+      }
+      cb && cb();
+    });
+  } else {
+    new sjcl.test.TestCase("Keccak-r" + rate + "c" + capacity + " from Keccak KAT", function (cb) {
+      var keccak;
+      try {
+        keccak = sjcl.hash.keccak(capacity, 4096, capacity + rate);
+      } catch (e) {
+        this.unimplemented();
+        cb && cb();
+        return;
+      }
+
+      var i, kat=sjcl.test.vector['keccak_r' + rate + 'c' + capacity], p=0, f=0;
+      for (i=0; i<kat.length; i++) {
+        var data = sjcl.bitArray.clamp(sjcl.codec.hex.toBits(kat[i][1]), kat[i][0]);
+        var out = keccak.hash(data, kat[i][2].length * 4);
+        this.require(sjcl.bitArray.equal(out, sjcl.codec.hex.toBits(kat[i][2])), i+": "+sjcl.codec.hex.fromBits(out) + " != " + kat[i][2]);
+      }
+      cb && cb();
+    });
+  }
+}
+
+function test_sha3(security) {
+  var name = 'sha3_' + security;
+  new sjcl.test.TestCase("SHA3-" + security + " based on Keccak[" + (2*security) + "]", function (cb) {
+    if (!sjcl.hash[name]) {
+      this.unimplemented();
+      cb && cb();
+      return;
+    }
+
+    var i, kat, sha3=sjcl.hash[name];
+    kat=sjcl.test.vector[name];
+    for (i=0; i<kat.length; i++) {
+      // clamp after byteswap! these test vectors have the bytes already aligned,
+      // clamping before swapping would kill needed bits.
+      var data = sjcl.bitArrayLE.clampM(sjcl.bitArrayLE.fromBitArrayByteSwap(sjcl.codec.hex.toBits(kat[i][1])), kat[i][0]);
+      var out = sha3().updateLE(data).finalize();
+      this.require(sjcl.bitArray.equal(out, sjcl.codec.hex.toBits(kat[i][2])), i+": "+sjcl.codec.hex.fromBits(out) + " != " + kat[i][2]);
+    }
+    kat=sjcl.test.vector[name + '_strings'];
+    for (i=0; i<kat.length; i++) {
+      var out = sha3.hash(kat[i][0]);
+      this.require(sjcl.bitArray.equal(out, sjcl.codec.hex.toBits(kat[i][1])), i+": "+sjcl.codec.hex.fromBits(out) + " != " + kat[i][1]);
+    }
+    cb && cb();
+  });
+}
+
+function test_sha3_shake(security) {
+  var name = 'shake' + security;
+  new sjcl.test.TestCase("SHAKE" + security + " based on Keccak[" + (2*security) + "]", function (cb) {
+    if (!sjcl.hash[name]) {
+      this.unimplemented();
+      cb && cb();
+      return;
+    }
+
+    var i, kat, sha3=sjcl.hash[name];
+    kat=sjcl.test.vector[name];
+    for (i=0; i<kat.length; i++) {
+      // clamp after byteswap! these test vectors have the bytes already aligned,
+      // clamping before swapping would kill needed bits.
+      var data = sjcl.bitArrayLE.clampM(sjcl.bitArrayLE.fromBitArrayByteSwap(sjcl.codec.hex.toBits(kat[i][1])), kat[i][0]);
+      var expected = sjcl.codec.hex.toBits(kat[i][2]);
+      var out = sha3().updateLE(data).finalize(sjcl.bitArray.bitLength(expected));
+      this.require(sjcl.bitArray.equal(out, expected), i+": "+sjcl.codec.hex.fromBits(out) + " != " + kat[i][2]);
+    }
+    cb && cb();
+  });
+}
+
+
+test_keccak(448);
+test_keccak(512);
+test_keccak(768);
+test_keccak(1024);
+
+test_keccak(272, 128);
+test_keccak(256, 1344);
+test_keccak(256, 144);
+test_keccak(544, 256);
+test_keccak(160, 40);
+test_keccak(288, 512);
+test_keccak(256, 544);
+
+test_sha3(224);
+test_sha3(256);
+test_sha3(384);
+test_sha3(512);
+
+test_sha3_shake(128);
+test_sha3_shake(256);


### PR DESCRIPTION
Also depends on #163 for byteswapM.

The implemenation uses the current [draft](http://csrc.nist.gov/publications/drafts/fips-202/fips_202_draft.pdf), and I think it is unlikely to change now:
* Use `2*bits` as capacity again if `bits` is the intended security level used in the name
* Sponge uses "10*1" padding (this was always the case)
* SHA3 "pads" (domain separation before sponge padding) with "01" (in little endian, becomes `10b` big endian)
* SHAKE "pads" with "1111"

The test vectors are quite large (11MB).