### PR TITLE
[FIX] Point coordinates should be converted to psuedo mersenne primes

### DIFF
--- a/core/ecc.js
+++ b/core/ecc.js
@@ -14,8 +14,16 @@ sjcl.ecc.point = function(curve,x,y) {
   if (x === undefined) {
     this.isIdentity = true;
   } else {
+    if (x instanceof sjcl.bn) {
+      x = new curve.field(x);
+    }
+    if (y instanceof sjcl.bn) {
+      y = new curve.field(y);
+    }
+
     this.x = x;
     this.y = y;
+
     this.isIdentity = false;
   }
   this.curve = curve;


### PR DESCRIPTION
Just a small fix that makes the constructor more robust. If you pass in `bn`s (a common mistake), you get very strange behavior for no apparent reason.

Since `bn` is a parent class of `pseudoMersennePrime`, it has most of the same functions, so you get pretty far without noticing anything wrong. Usually, the error is simply that SJCL hangs as number are getting larger and larger (operations modulo a pseudoMersennePrime are finite, regular integer arithmetic is not.)
