### PR TITLE
Fix mouse move event errors

### DIFF
--- a/core/random.js
+++ b/core/random.js
@@ -405,7 +405,10 @@ sjcl.prng.prototype = {
       y = 0;
     }
 
-    sjcl.random.addEntropy([x,y], 2, "mouse");
+    if (x != 0 && y!= 0) {
+      sjcl.random.addEntropy([x,y], 2, "mouse");
+    }
+
     this._addCurrentTimeToEntropy(0);
   },
   


### PR DESCRIPTION
Catch permission errors thrown by firefox when trying to access the mouse move event object originating from special elements.

Fixes #184.
