### PR TITLE
This type check fixes a problem with <IE10 browsers

### DIFF
--- a/core/random.js
+++ b/core/random.js
@@ -404,7 +404,7 @@ sjcl.prng.prototype = {
   },
 
   _addCurrentTimeToEntropy: function (estimatedEntropy) {
-    if (window && window.performance && typeof window.performance.now === "function") {
+    if (typeof window !== 'undefined' && window.performance && typeof window.performance.now === "function") {
       //how much entropy do we want to add here?
       sjcl.random.addEntropy(window.performance.now(), estimatedEntropy, "loadtime");
     } else {
@@ -470,7 +470,7 @@ sjcl.random = new sjcl.prng(6);
       buf = new Uint32Array(new Uint8Array(buf).buffer);
       sjcl.random.addEntropy(buf, 1024, "crypto.randomBytes");
 
-    } else if (window && Uint32Array) {
+    } else if (typeof window !== 'undefined' && typeof Uint32Array !== 'undefined') {
       ab = new Uint32Array(32);
       if (window.crypto && window.crypto.getRandomValues) {
         window.crypto.getRandomValues(ab);


### PR DESCRIPTION
I noticed this was causing errors with browsers that doesn't have `Uint32Arrays`.

Problem simply was that JS throws an error if you're trying to access a global variable that isn't defined. I just added proper type checks for those places.

The check for `window` doesn't really matter for browsers, but if someone's running this outside of browser environment (Rhino/Node/etc), they would have encountered the same problem, so I fixed those too.
