### PR TITLE
Adding check for max IV Length

### DIFF
--- a/core/ccm.js
+++ b/core/ccm.js
@@ -29,8 +29,8 @@ sjcl.mode.ccm = {
     tlen = tlen || 64;
     adata = adata || [];
     
-    if (ivl < 7) {
-      throw new sjcl.exception.invalid("ccm: iv must be at least 7 bytes");
+    if (ivl < 7 || ivl > 13) {
+      throw new sjcl.exception.invalid("ccm: iv must be between 7 and 13 bytes");
     }
     
     // compute the length of the length


### PR DESCRIPTION
As per Github issue #180, there is no upper bound check
for AES-CCM IV length.  This PR address the issue by
placing a check for the upper bound (13 bytes) for the IV
length.