### PR TITLE
Remove leading zero limbs in sjcl.bn.normalize

### DIFF
--- a/core/bn.js
+++ b/core/bn.js
@@ -496,6 +496,9 @@ sjcl.bn.prototype = {
     if (carry === -1) {
       limbs[i-1] -= pv;
     }
+    while (limbs.length > 0 && limbs[limbs.length-1] === 0) {
+      limbs.pop();
+    }
     return this;
   },
 

--- a/test/bn_test.js
+++ b/test/bn_test.js
@@ -65,3 +65,14 @@ new sjcl.test.TestCase("Bignum modular exponentiation test", function (cb) {
   }
   cb && cb();
 });
+
+new sjcl.test.TestCase("Bignum toString test", function (cb) {
+  if (!sjcl.bn) {
+    this.unimplemented();
+    cb && cb();
+    return;
+  }
+  this.require((new sjcl.bn(12312434)).power(10).toString() ===
+    '0xb99c06973dcc72429aa1dd41b0bc40a424289a05d3d72f066ee4e71c400');
+  cb && cb();
+});


### PR DESCRIPTION
This fixes an issue with sjcl.bn where `a.toString() != b.toString()` even if `a.equals(b)` is true.