### PR TITLE
Ignore development files in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,20 @@
 {
 	"name": "sjcl",
 	"version": "1.0.3",
-	"main": ["./sjcl.js"]
+	"main": ["./sjcl.js"],
+  "ignore": [
+    ".*",
+    "*.md",
+    "Makefile",
+    "config.mk",
+    "configure",
+    "package.json",
+    "browserTest",
+    "compress",
+    "core",
+    "demo",
+    "jsdoc_toolkit-2.3.3-beta",
+    "lint",
+    "test"
+  ]
 }


### PR DESCRIPTION
Previously, no `ignore` list was specificed in `bower.json`. When using
`sjcl` in production, this resulted in unnecessary files beeing part
of the code base.

Ignoring the develpment files is common practice in other bower packages, examples:

[lodash](https://github.com/lodash/lodash/blob/master/bower.json), [Ionic](https://github.com/driftyco/ionic/blob/master/bower.json), [Twitter Bootstrap](https://github.com/twbs/bootstrap/blob/master/bower.json), etc.

I discovered this by using `sjcl` with an Ionic project and building the app under iOS failed because the build script was breaking because of shell scripts and other stuff part of the `sjcl` directory.