### PR TITLE
demo: decode authenticated data to a string on decrypt

### DIFF
--- a/demo/example.js
+++ b/demo/example.js
@@ -108,7 +108,7 @@ function doDecrypt() {
     }
     v.mode = rp.mode;
     v.iv = rp.iv;
-    v.adata = rp.adata;
+    v.adata = sjcl.codec.utf8String.fromBits(rp.adata);
     if (v.password) {
       v.salt = rp.salt;
       v.iter = rp.iter;


### PR DESCRIPTION
On decryption, authenticated data is provided as a bit array in the
returned version while, previously, it was merely a copy of the provided
string. In the demo, we need to turn it back to a string before
displaying it to the user.