### PR TITLE
Fix #216 Extra 0 produced by base32 encoding

### DIFF
--- a/core/codecBase32.js
+++ b/core/codecBase32.js
@@ -22,7 +22,7 @@ sjcl.codec.base32 = {
     var BITS = sjcl.codec.base32.BITS, BASE = sjcl.codec.base32.BASE, REMAINING = sjcl.codec.base32.REMAINING;
     var out = "", i, bits=0, c = sjcl.codec.base32._chars, ta=0, bl = sjcl.bitArray.bitLength(arr);
 
-    for (i=0; out.length * BASE <= bl; ) {
+    for (i=0; out.length * BASE < bl; ) {
       out += c.charAt((ta ^ arr[i]>>>bits) >>> REMAINING);
       if (bits < BASE) {
         ta = arr[i] << (BASE-bits);


### PR DESCRIPTION
When the number of bits is a multiple of 40, an extra `0` is appended to the base32 string. Every 40 bits should produce 8 characters, but exactly 40 bits is producing 9 characters, the last being `0`.

This fixes that problem. (Fixes #216)