### PR TITLE
Fix Base32 Alphabet

### DIFF
--- a/core/codecBase32.js
+++ b/core/codecBase32.js
@@ -8,7 +8,7 @@ sjcl.codec.base32 = {
   /** The base32 alphabet.
    * @private
    */
-  _chars: "0123456789abcdefghjkmnpqrstvwxyz",
+  _chars: "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567",
 
   /* bits in an array */
   BITS: 32,


### PR DESCRIPTION
As specified in [RFC 4648](http://tools.ietf.org/html/rfc4648#section-6)