### PR TITLE
SHA functions made faster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,9 +73,12 @@ TEST_SCRIPTS= $(TEST_COMMON) \
               test/pbkdf2_test.js test/scrypt_vectors.js test/scrypt_test.js \
               test/ripemd160_vectors.js test/ripemd160_test.js \
               test/sha1_vectors.js test/sha1_test.js \
+              test/sha1_vectors_long_messages.js test/sha1_test_long_messages.js \
               test/sha256_vectors.js test/sha256_test.js \
+              test/sha256_vectors_long_messages.js test/sha256_test_long_messages.js \
               test/sha256_test_brute_force.js \
               test/sha512_vectors.js test/sha512_test.js \
+              test/sha512_vectors_long_messages.js test/sha512_test_long_messages.js \
               test/sha512_test_brute_force.js \
               test/srp_vectors.js test/srp_test.js
 

--- a/core/sha1.js
+++ b/core/sha1.js
@@ -143,7 +143,7 @@ sjcl.hash.sha1.prototype = {
   
   /**
    * Perform one cycle of SHA-1.
-   * @param {bitArray} words one block of words.
+   * @param {Uint32Array|bitArray} words one block of words.
    * @private
    */
   _block:function (words) {

--- a/core/sha1.js
+++ b/core/sha1.js
@@ -156,7 +156,7 @@ sjcl.hash.sha1.prototype = {
         // The problem is that if we use Uint32Array instead of Array, 
         // the length of Uint32Array cannot be changed. Thus, we replace words with a 
         // normal Array here.
-        w = Array(80);
+        w = Array(80); // do not use Uint32Array here as the instantiation is slower
         for (var j=0; j<16; j++){
             w[j] = words[j];
         }

--- a/core/sha1.js
+++ b/core/sha1.js
@@ -61,9 +61,20 @@ sjcl.hash.sha1.prototype = {
     var i, b = this._buffer = sjcl.bitArray.concat(this._buffer, data),
         ol = this._length,
         nl = this._length = ol + sjcl.bitArray.bitLength(data);
-    for (i = this.blockSize+ol & -this.blockSize; i <= nl;
-         i+= this.blockSize) {
-      this._block(b.splice(0,16));
+    if (typeof Uint32Array !== 'undefined') {
+	var c = new Uint32Array(b);
+    	var j = 0;
+    	for (i = this.blockSize+ol & -this.blockSize; i <= nl; 
+		i+= this.blockSize) {
+      	    this._block(c.subarray(16 * j, 16 * (j+1)));
+      	    j += 1;
+    	}
+    	b.splice(0, 16 * j);
+    } else {
+    	for (i = this.blockSize+ol & -this.blockSize; i <= nl;
+             i+= this.blockSize) {
+      	     this._block(b.splice(0,16));
+      	}
     }
     return this;
   },
@@ -135,11 +146,24 @@ sjcl.hash.sha1.prototype = {
    * @param {bitArray} words one block of words.
    * @private
    */
-  _block:function (words) {  
+  _block:function (words) {
     var t, tmp, a, b, c, d, e,
-    w = words.slice(0),
     h = this._h;
-   
+    var w;
+    if (typeof Uint32Array !== 'undefined') {
+        // When words is passed to _block, it has 16 elements. SHA1 _block
+        // function extends words with new elements (at the end there are 80 elements). 
+        // The problem is that if we use Uint32Array instead of Array, 
+        // the length of Uint32Array cannot be changed. Thus, we replace words with a 
+        // normal Array here.
+        w = Array(80);
+        for (var j=0; j<16; j++){
+            w[j] = words[j];
+        }
+    } else {
+        w = words;
+    }
+
     a = h[0]; b = h[1]; c = h[2]; d = h[3]; e = h[4]; 
 
     for (t=0; t<=79; t++) {

--- a/core/sha256.js
+++ b/core/sha256.js
@@ -167,7 +167,7 @@ sjcl.hash.sha256.prototype = {
   
   /**
    * Perform one cycle of SHA-256.
-   * @param {bitArray} words one block of words.
+   * @param {Uint32Array|bitArray} words one block of words.
    * @private
    */
   _block:function (w) {  

--- a/core/sha256.js
+++ b/core/sha256.js
@@ -69,8 +69,19 @@ sjcl.hash.sha256.prototype = {
     var i, b = this._buffer = sjcl.bitArray.concat(this._buffer, data),
         ol = this._length,
         nl = this._length = ol + sjcl.bitArray.bitLength(data);
-    for (i = 512+ol & -512; i <= nl; i+= 512) {
-      this._block(b.splice(0,16));
+
+    if (typeof Uint32Array !== 'undefined') {
+	var c = new Uint32Array(b);
+    	var j = 0;
+    	for (i = 512+ol & -512; i <= nl; i+= 512) {
+      	    this._block(c.subarray(16 * j, 16 * (j+1)));
+      	    j += 1;
+    	}
+    	b.splice(0, 16 * j);
+    } else {
+	for (i = 512+ol & -512; i <= nl; i+= 512) {
+      	    this._block(b.splice(0,16));
+      	}
     }
     return this;
   },
@@ -159,9 +170,8 @@ sjcl.hash.sha256.prototype = {
    * @param {bitArray} words one block of words.
    * @private
    */
-  _block:function (words) {  
+  _block:function (w) {  
     var i, tmp, a, b,
-      w = words.slice(0),
       h = this._h,
       k = this._key,
       h0 = h[0], h1 = h[1], h2 = h[2], h3 = h[3],

--- a/core/sha512.js
+++ b/core/sha512.js
@@ -232,7 +232,7 @@ sjcl.hash.sha512.prototype = {
 	// The problem is that if we use Uint32Array instead of Array, 
 	// the length of Uint32Array cannot be changed. Thus, we replace words with a 
 	// normal Array here.
-        w = Array(160);
+        w = Array(160); // do not use Uint32Array here as the instantiation is slower
         for (var j=0; j<32; j++){
     	    w[j] = words[j]; 
         }

--- a/core/sha512.js
+++ b/core/sha512.js
@@ -214,11 +214,10 @@ sjcl.hash.sha512.prototype = {
 
   /**
    * Perform one cycle of SHA-512.
-   * @param {bitArray} words one block of words.
+   * @param {Uint32Array|bitArray} words one block of words.
    * @private
    */
   _block:function (words) {
-    //se za uint32array undefined
     var i, wrh, wrl,
         h = this._h,
         k = this._key,

--- a/test/sha1_test_long_messages.js
+++ b/test/sha1_test_long_messages.js
@@ -1,0 +1,14 @@
+new sjcl.test.TestCase("SHA-1 long messages", function (cb) {
+  if (!sjcl.hash.sha1) {
+    this.unimplemented();
+    cb && cb();
+    return;
+  }
+  
+  var i, kat=sjcl.test.vector.sha1long, p=0, f=0;
+  for (i=0; i<kat.length; i++) {
+    var out = sjcl.hash.sha1.hash(kat[i][0]);
+    this.require(sjcl.codec.hex.fromBits(out) == kat[i][1], i);
+  }
+  cb && cb();
+});

--- a/test/sha1_vectors_long_messages.js
+++ b/test/sha1_vectors_long_messages.js
@@ -1,0 +1,5 @@
+// generated with: printf 'a123456%.0s' {1..99999} | sha1sum
+sjcl.test.vector.sha1long = 
+[
+[Array(100000).join('a123456'), "fd8513d5ba504eacf786091af50b75dcfe25b145"]
+]

--- a/test/sha256_test_long_messages.js
+++ b/test/sha256_test_long_messages.js
@@ -1,0 +1,14 @@
+new sjcl.test.TestCase("SHA-256 long messages", function (cb) {
+  if (!sjcl.hash.sha256) {
+    this.unimplemented();
+    cb && cb();
+    return;
+  }
+  
+  var i, kat=sjcl.test.vector.sha256long, p=0, f=0;
+  for (i=0; i<kat.length; i++) {
+    var out = sjcl.hash.sha256.hash(kat[i][0]);
+    this.require(sjcl.codec.hex.fromBits(out) == kat[i][1], i);
+  }
+  cb && cb();
+});

--- a/test/sha256_vectors_long_messages.js
+++ b/test/sha256_vectors_long_messages.js
@@ -1,0 +1,5 @@
+// generated with: printf 'a123456%.0s' {1..99999} | sha256sum
+sjcl.test.vector.sha256long = 
+[
+[Array(100000).join('a123456'), "397df3bf09b046b41b65edebd20e440308188e441c7e57e400cad21b86333d77"]
+]

--- a/test/sha512_test_long_messages.js
+++ b/test/sha512_test_long_messages.js
@@ -1,0 +1,14 @@
+new sjcl.test.TestCase("SHA-512 long messages", function (cb) {
+  if (!sjcl.hash.sha512) {
+    this.unimplemented();
+    cb && cb();
+    return;
+  }
+  
+  var i, kat=sjcl.test.vector.sha512long, p=0, f=0;
+  for (i=0; i<kat.length; i++) {
+    var out = sjcl.hash.sha512.hash(kat[i][0]);
+    this.require(sjcl.codec.hex.fromBits(out) == kat[i][1], i);
+  }
+  cb && cb();
+});

--- a/test/sha512_vectors_long_messages.js
+++ b/test/sha512_vectors_long_messages.js
@@ -1,0 +1,5 @@
+// generated with: printf 'a123456%.0s' {1..99999} | sha512sum
+sjcl.test.vector.sha512long = 
+[
+[Array(100000).join('a123456'), "17e8ca98b80c7193720de18f59898012bb2d33529d6833950b1ec014d594ecf30f9a6c60d8c5c215d4326e3632198f3937003a68477609bd388b8ae0ba62ccf7"]
+]


### PR DESCRIPTION
Usage of splice function in SHA-1, SHA-256, SHA-512 makes these functions very slow for large messages. Using Uint32Array instead of Array to avoid splicing makes SHA functions much faster (50x for SHA-256, 15x for SHA-512) for large messages and slightly slower for small messages.

Some tests are added to check the performance for large messages (see test/*_long_messages.js).