### PR TITLE
Serialization/deserialization of public keys added; serialization tests added

### DIFF
--- a/test/ecdh_test.js
+++ b/test/ecdh_test.js
@@ -9,6 +9,25 @@ new sjcl.test.TestCase("ECDH test", function (cb) {
     var keys = sjcl.ecc.elGamal.generateKeys(192,0),
         keyTag = keys.pub.kem(0),
         key2 = keys.sec.unkem(keyTag.tag);
+
+    var serializedPubKey = keys.pub.serialize();
+    var deserializedPubKey = sjcl.ecc.deserialize(serializedPubKey);
+    var serializedSecKey = keys.sec.serialize();
+    var deserializedSecKey = sjcl.ecc.deserialize(serializedSecKey);
+
+    this.require(sjcl.bitArray.equal(keys.pub.get().x, 
+	deserializedPubKey.get().x));
+    this.require(sjcl.bitArray.equal(keys.pub.get().y, 
+	deserializedPubKey.get().y));
+    this.require(sjcl.bitArray.equal(deserializedSecKey.get(), keys.sec.get()));
+
+    var ciphertext = sjcl.encrypt(deserializedPubKey, "hello world");
+    var plaintext  = sjcl.decrypt(keys.sec, ciphertext);
+    this.require(plaintext == "hello world");
+
+    ciphertext = sjcl.encrypt(keys.pub, "hello world");
+    plaintext  = sjcl.decrypt(deserializedSecKey, ciphertext);
+    this.require(plaintext == "hello world");
         
     this.require(sjcl.bitArray.equal(keyTag.key, key2));
   } catch(e) {

--- a/test/ecdsa_test.js
+++ b/test/ecdsa_test.js
@@ -15,7 +15,33 @@ new sjcl.test.TestCase("ECDSA test", function (cb) {
   } catch (e) {
     this.fail("good message rejected");
   }
-  
+
+  var serializedPubKey = keys.pub.serialize();
+  var deserializedPubKey = sjcl.ecc.deserialize(serializedPubKey);
+  var serializedSecKey = keys.sec.serialize();
+  var deserializedSecKey = sjcl.ecc.deserialize(serializedSecKey);
+  var signatureAfterSerialization = deserializedSecKey.sign(hash,0);
+
+  this.require(sjcl.bitArray.equal(keys.pub.get().x,       
+      deserializedPubKey.get().x));
+  this.require(sjcl.bitArray.equal(keys.pub.get().y,
+      deserializedPubKey.get().y));
+  this.require(sjcl.bitArray.equal(deserializedSecKey.get(), keys.sec.get()));
+
+  try {
+    deserializedPubKey.verify(hash, signature);
+    this.pass();
+  } catch (e) {
+    this.fail("good message rejected after serialization and deserialization of public key");
+  }
+
+  try {
+    keys.pub.verify(hash, signatureAfterSerialization);
+    this.pass();
+  } catch (e) {
+    this.fail("signature provided with serialized/deserialized secret key rejected");
+  }
+
   hash[1] ^= 8; // minor change to hash
   
   try {


### PR DESCRIPTION
Serialization/deserialization code was taken from #99, however ecc.js was significantly changed in the meantime and the serialization code needed to be moved to basicKey class, this is why I opened a new PR. Tests have been added.

Note that extendedArguments could be avoided if we change the return statement of basicKey.generateKeys from
```Javascript
return { pub: new sjcl.ecc[cn].publicKey(curve, pub),
             sec: new sjcl.ecc[cn].secretKey(curve, sec) };
```
to
```Javascript
return { pub: new sjcl.ecc[cn].publicKey(curve, pub, cn),
             sec: new sjcl.ecc[cn].secretKey(curve, sec), cn };
```

but it doesn't feel right pushing cn argument twice into it.
