### PR TITLE
fix to issue #253 not clear how this software is licenced

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 SJCL is open. You can use, modify and redistribute it under a BSD
-license or under the GNU GPL, version 2.0 or higher (of either license).
+license or under the GNU GPL, version 2.0.
 
 ---------------------------------------------------------------------
 

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,58 @@
+SJCL is open. You can use, modify and redistribute it under a BSD
+license or under the GNU GPL, version 2.0 or higher (of either license).
+
+---------------------------------------------------------------------
+
+http://opensource.org/licenses/BSD-2-Clause
+
+Copyright (c) 2009-2015, Emily Stark, Mike Hamburg and Dan Boneh at
+Stanford University. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+---------------------------------------------------------------------
+
+http://opensource.org/licenses/GPL-2.0
+
+The Stanford Javascript Crypto Library (hosted here on GitHub) is a
+project by the Stanford Computer Security Lab to build a secure,
+powerful, fast, small, easy-to-use, cross-browser library for
+cryptography in Javascript.
+
+Copyright (c) 2009-2015, Emily Stark, Mike Hamburg and Dan Boneh at
+Stanford University.
+
+This program is free software; you can redistribute it and/or modify it
+under the terms of the GNU General Public License as published by the
+Free Software Foundation; either version 2 of the License, or (at your
+option) any later version.
+
+This program is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+59 Temple Place, Suite 330, Boston, MA 02111-1307 USA


### PR DESCRIPTION
This license: 

1) Has the paragraph of what is said at http://bitwiseshiftleft.github.io/sjcl/ in terms of which licenses are avaiable. There was a choice at http://opensource.org/licenses of using 2 clause of 3 clause BSD. The two clause version closely matches the GPL2 version so I opted for that. 

2) Follows the statements at both http://opensource.org/licenses/BSD-2-Clause and http://opensource.org/licenses/GPL-2.0 in terms of asserting copyright and putting the appropriate legalese into the license. The copyright was asserted to the authors of the original stanford paper. The idea being that if their is a legal dispute about use of the software then whoever takes up the fight in court (usually the FSF else the university) would bring the case on behalf of the parties claiming copyright or their estate if they are dead. 