### PR TITLE
Fix ECC test condition

### DIFF
--- a/test/ecc_test.js
+++ b/test/ecc_test.js
@@ -1,5 +1,5 @@
 new sjcl.test.TestCase("ECC point multiplication test", function (cb) {
-  if (!sjcl.bn) {
+  if (!sjcl.ecc) {
     this.unimplemented();
     cb && cb();
     return;


### PR DESCRIPTION
Test suite fails if ecc is not included due to wrong condition