### PR TITLE
Add missing version to bower.json file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,4 +1,5 @@
 {
-	"name": "sjcl",
-	"main": ["./sjcl.js"]
+    "name": "sjcl",
+    "version": "1.0.4",
+    "main": ["./sjcl.js"]
 }


### PR DESCRIPTION
I've added the version to the bower file; the version should be listed there.

i nootice also that it is missing the tag for release 1.0.4

In addition in general that file should reflect quite hte package json with all the other variables like the license as for ticket https://github.com/bitwiseshiftleft/sjcl/issues/253

