### PR TITLE
Fixes for different compatibility issues.

### DIFF
--- a/configure
+++ b/configure
@@ -34,6 +34,7 @@ my %deps = ('aes'=>'sjcl',
             'codecArrayBuffer'=>'bitArray');
 
 my $compress = "closure";
+my $exported = 1;
 
 my %enabled = ();
 $enabled{$_} = 0 foreach (@targets);
@@ -73,6 +74,8 @@ while (my $arg = shift @ARGV) {
     $enabled{$targ} = -1;
   } elsif ($arg =~ /^--?compress(?:or|ion)?=(none|closure|yui)$/) {
     $compress = $1;
+  } elsif ($arg =~ /^--?no-export$/) {
+    $exported = 0;
   } else {
     my $targets = join " ", @targets;
     $targets =~ s/sjcl //;
@@ -88,6 +91,8 @@ Valid arguments are:
 
   --with-TARGET: require TARGET
   --without-TARGET: forbid TARGET
+
+  --no-export: do not export sjcl
 
   --help: show this message
 
@@ -119,6 +124,8 @@ foreach my $i (@targets) {
     }
   }
 }
+
+$config = "exports $config" if $exported;
 
 # reverse
 foreach my $i (reverse @targets) {

--- a/core/exports.js
+++ b/core/exports.js
@@ -1,0 +1,8 @@
+if(typeof module !== 'undefined' && module.exports){
+  module.exports = sjcl;
+}
+if (typeof define === "function") {
+    define([], function () {
+        return sjcl;
+    });
+}

--- a/core/sha256.js
+++ b/core/sha256.js
@@ -145,23 +145,25 @@ sjcl.hash.sha256.prototype = {
    * @private
    */
   _precompute: function () {
-    var i = 0, prime = 2, factor;
+    var i = 0, prime = 2, factor, isPrime;
 
     function frac(x) { return (x-Math.floor(x)) * 0x100000000 | 0; }
 
-    outer: for (; i<64; prime++) {
+    for (; i<64; prime++) {
+      isPrime = true;
       for (factor=2; factor*factor <= prime; factor++) {
         if (prime % factor === 0) {
-          // not a prime
-          continue outer;
+          isPrime = false;
+          break;
         }
       }
-      
-      if (i<8) {
-        this._init[i] = frac(Math.pow(prime, 1/2));
+      if (isPrime) {
+        if (i<8) {
+          this._init[i] = frac(Math.pow(prime, 1/2));
+        }
+        this._key[i] = frac(Math.pow(prime, 1/3));
+        i++;
       }
-      this._key[i] = frac(Math.pow(prime, 1/3));
-      i++;
     }
   },
   

--- a/core/sha512.js
+++ b/core/sha512.js
@@ -189,26 +189,28 @@ sjcl.hash.sha512.prototype = {
   _precompute: function () {
     // XXX: This code is for precomputing the SHA256 constants, change for
     //      SHA512 and re-enable.
-    var i = 0, prime = 2, factor;
+    var i = 0, prime = 2, factor , isPrime;
 
     function frac(x)  { return (x-Math.floor(x)) * 0x100000000 | 0; }
     function frac2(x) { return (x-Math.floor(x)) * 0x10000000000 & 0xff; }
 
-    outer: for (; i<80; prime++) {
+    for (; i<80; prime++) {
+      isPrime = true;
       for (factor=2; factor*factor <= prime; factor++) {
         if (prime % factor === 0) {
-          // not a prime
-          continue outer;
+          isPrime = false;
+          break;
         }
       }
-
-      if (i<8) {
-        this._init[i*2] = frac(Math.pow(prime, 1/2));
-        this._init[i*2+1] = (frac2(Math.pow(prime, 1/2)) << 24) | this._initr[i];
+      if (isPrime) {
+        if (i<8) {
+          this._init[i*2] = frac(Math.pow(prime, 1/2));
+          this._init[i*2+1] = (frac2(Math.pow(prime, 1/2)) << 24) | this._initr[i];
+        }
+        this._key[i*2] = frac(Math.pow(prime, 1/3));
+        this._key[i*2+1] = (frac2(Math.pow(prime, 1/3)) << 24) | this._keyr[i];
+        i++;
       }
-      this._key[i*2] = frac(Math.pow(prime, 1/3));
-      this._key[i*2+1] = (frac2(Math.pow(prime, 1/3)) << 24) | this._keyr[i];
-      i++;
     }
   },
 

--- a/core/sjcl.js
+++ b/core/sjcl.js
@@ -67,12 +67,3 @@ var sjcl = {
     }
   }
 };
-
-if(typeof module !== 'undefined' && module.exports){
-  module.exports = sjcl;
-}
-if (typeof define === "function") {
-    define([], function () {
-        return sjcl;
-    });
-}


### PR DESCRIPTION
DemandWare environment uses slightly modified Rhino JS engine which gives "Ambiguous label" error for the labels in _precompute functions for hashes (probably because they use typed variables and a colon after the name make the compiler confused). The patch has fixed that by the removing the labels all together.