### PR TITLE
Add performance tests for PBKDF2

### DIFF
--- a/browserTest/browserUtil.js
+++ b/browserTest/browserUtil.js
@@ -123,6 +123,35 @@ browserUtil.write = function(type, message) {
   }};
 };
 
+browserUtil.writeTable = function (headers) {
+  var d1 = document.getElementById("print"), d2 = document.createElement("table"), d3 = document.createElement("tr");
+  d2.className = 'table';
+
+  // write the headers
+  for (var i = 0; i < headers.length; i++) {
+    var header = document.createElement("th");
+    header.appendChild(document.createTextNode(headers[i]));
+    d3.appendChild(header);
+  }
+
+  d2.appendChild(d3);
+  d1.appendChild(d2);
+
+  return { update: function (row) {
+    var d4 = document.createElement("tr");
+
+    // write the rows
+    for (var i = 0; i < row.length; i++) {
+      var cell = document.createElement("td");
+
+      cell.appendChild(document.createTextNode(row[i]));
+      d4.appendChild(cell);
+    }
+
+    d2.appendChild(d4);
+  }};
+}
+
 /** Write a newline.  Does nothing in the browser. */
 browserUtil.writeNewline = function () { };
 

--- a/browserTest/performance.html
+++ b/browserTest/performance.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>SJCL browser performance</title>
+  <link rel="stylesheet" type="text/css" href="test.css"/>
+</head>
+<body>
+  <h1>SJCL browser performance</h1>
+  <div id="status">Waiting for tests to begin...</div>
+  <div id="print"></div>
+  <script type="text/javascript" src="../sjcl.js"></script>
+  <script type="text/javascript" src="browserUtil.js"></script>
+  <script type="text/javascript" src="performance.js"></script>
+</body>
+</html>

--- a/browserTest/performance.js
+++ b/browserTest/performance.js
@@ -1,0 +1,70 @@
+sjcl.perf = { all: {} };
+
+sjcl.perf.PerfCase = function PerfCase (name, cases, runCase) {
+  this.name = name;
+  this.cases = cases;
+  this.runCase = runCase;
+  sjcl.perf.all[name] = this;
+}
+
+sjcl.perf.PerfCase.prototype.run = function (callback) {
+  var thiz = this;
+
+  var repo = browserUtil.write("info", "Running " + this.name + "...");
+  var table = browserUtil.writeTable(["iter", "time"]);
+
+  thiz.runCase(this.cases[0]); // cold start
+
+  browserUtil.cpsMap(function (t, i, n, cb) {
+      var runs = []
+
+      // do 3 runs and average them
+      for (var k = 0; k < 3; k++) {
+        var t0 = performance.now();
+        thiz.runCase(t);
+        var t1 = performance.now();
+        runs.push(t1 - t0);
+      }
+
+      var avg = runs.reduce(function(a, b) { return a + b; }) / runs.length;
+      table.update([t, avg.toFixed(3) + ' ms']);
+
+      cb && cb();
+  }, this.cases, true, function() {
+
+    repo.update("pass", "done.");
+    callback();
+
+  });
+}
+
+sjcl.perf.run = function (perfs, callback) {
+  browserUtil.status("Profiling...");
+
+  var t;
+  if (perfs === undefined || perfs.length == 0) {
+    perfs = [];
+    for (t in sjcl.perf.all) {
+      if (sjcl.perf.all.hasOwnProperty(t)) {
+        perfs.push(t);
+      }
+    }
+  }
+
+  browserUtil.cpsMap(function (t, i, n, cb) {
+    sjcl.perf.all[perfs[i]].run(cb);
+  }, perfs, true, callback);
+};
+
+
+// performance case for pbkdf2
+var cases = [1000, 2000, 4000, 8000, 16000, 32000, 48000, 64000];
+new sjcl.perf.PerfCase("pbkdf2", cases,
+  function (iter) {
+    sjcl.misc.pbkdf2("mypassword", "01234567890123456789", iter);
+  }
+);
+
+sjcl.perf.run([], function() {
+  browserUtil.status("");
+});

--- a/browserTest/test.css
+++ b/browserTest/test.css
@@ -57,3 +57,23 @@ h1 {
   height: 1.3em;
   vertical-align: middle;
 }
+
+.table {
+  width: 100%;
+  border-spacing: 0;
+  border-collapse: collapse;
+  margin: 5px 0;
+}
+
+.table td, .table th {
+  padding: 3px;
+  border: 1px solid #ddd;
+}
+
+.table td {
+  text-align: right;
+}
+
+.table tr:nth-of-type(odd) {
+  background: #f9f9f9;
+}


### PR DESCRIPTION
This is how the page looks right now:

<img width="870" alt="captura de pantalla 2016-05-29 a las 12 04 26 a m" src="https://cloud.githubusercontent.com/assets/138426/15631155/f33caace-2530-11e6-985d-760741b20f31.png">

Results for **MacBook Pro 2,7 GHz Intel Core i5**:

| iter  | time |
| ------------- | ------------- |
| 1000 | 12.603 ms |
| 2000 | 16.013 ms |
| 4000 | 23.180 ms |
| 8000 | 47.197 ms |
| 16000 | 93.533 ms |
| 32000 | 191.752 ms |
| 48000 | 279.633 ms |
| 64000 | 371.350 ms |

Results for **iPhone SE**:

| iter  | time |
| ------------- | ------------- |
| 1000 | 14.697 ms |
| 2000 | 25.298 ms |
| 4000 | 45.127 ms |
| 8000 | 90.638 ms |
| 16000 | 173.513 ms |
| 32000 | 346.902 ms |
| 48000 | 523.743 ms |
| 64000 | 695.372 ms |

Results for **Samsung S4 Mini**:

| iter  | time |
| ------------- | ------------- |
| 1000 | 90.532 ms |
| 2000 | 97.463 ms |
| 4000 | 184.423 ms |
| 8000 | 361.310 ms |
| 16000 | 755.023 ms |
| 32000 | 1550.385 ms |
| 48000 | 2361.818 ms |
| 64000 | 3420.530 ms |

I am not claiming this is a representative sample, but my rough guess is that we can increment the iteration count to about 10,000 without degrading too much the average user experience. While this number is not going to work for every use case, it provides a reasonable amount of security as of 2016.

cc/ @Nilos  ref/ #289 