### PR TITLE
Use fully-qualified names in docs

### DIFF
--- a/jsdoc.conf.json
+++ b/jsdoc.conf.json
@@ -1,0 +1,7 @@
+{
+  "templates": {
+    "default": {
+      "useLongnameInNav": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     },
     "scripts": {
       "test": "make test",
-      "jsdoc": "jsdoc",
+      "jsdoc": "jsdoc -c jsdoc.conf.json",
       "lint": "eslint . || true"
     },
     "engines": {


### PR DESCRIPTION
This is closer to the previous output and makes it easier to understand the structure of the library.

**Preview:**

<img width="486" alt="captura de pantalla 2016-05-31 a las 10 00 27 p m" src="https://cloud.githubusercontent.com/assets/138426/15695237/81611014-277b-11e6-836a-7b11821b6e17.png">
