### PR TITLE
Add documentation to ArrayBuffer.toBits

### DIFF
--- a/core/codecArrayBuffer.js
+++ b/core/codecArrayBuffer.js
@@ -63,7 +63,7 @@ sjcl.codec.arrayBuffer = {
 
     return out.buffer;
   },
-
+  /** Convert from an ArrayBuffer to a bitArray. */
   toBits: function (buffer) {
     var i, out=[], len, inView, tmp;
 


### PR DESCRIPTION
Fix ArrayBuffer.toBits not appearing in documentation output.