### PR TITLE
Fix attempting to load node crypto module outside of node.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
     "jsdoc": "jsdoc -c jsdoc.conf.json",
     "lint": "eslint . || true"
   },
+  "browser": {
+    "crypto": false
+  },
   "engines": {
     "node": "*"
   },


### PR DESCRIPTION
Specifying a browser override of `false` for the node `crypto` module prevents bundlers from attempting to shim the `crypto` module just because a `require('crypto')` call exists. (It is being used only in the [`random.js`](https://github.com/bitwiseshiftleft/sjcl/blob/2a6ed4a22449334de2dd9b4e960af679e0e87303/core/random.js#L485) file, in a try/catch so that the `crypto` module gets used if available, but SJCL will still work without it.)

This solves three problems:

1. Bundlers that do not automatically shim the `crypto` module will not produce missing dependency errors now.
2. Bundlers that do automatically shim the `crypto` module will no longer do so, providing smaller final builds.
3. Since SJCL is actually used in order to create shims of the `crypto` module, this eliminates some odd circular dependency issues. (In particular, the [`react-native-crypto`](https://github.com/mvayngrib/react-native-crypto/blob/daec565d903c529e29fa8e75b7624872308581e9/index.js#L3) shim ends up invoking SJCL through the [`react-native-randombytes`](https://github.com/mvayngrib/react-native-randombytes/blob/1efeba47af6b644085fb9ec0f47c60c85e80e5b7/index.js#L5) module.)

This will fix issues #362 and #371.