### PR TITLE
Bugfix. Now it supports non-numeric curve param(e.g. 'k256') in gener…

### DIFF
--- a/core/ecc.js
+++ b/core/ecc.js
@@ -518,11 +518,15 @@ sjcl.ecc.basicKey.generateKeys = function(cn) {
     curve = curve || 256;
 
     if (typeof curve === "number") {
-      curve = sjcl.ecc.curves['c'+curve];
-      if (curve === undefined) {
-        throw new sjcl.exception.invalid("no such curve");
-      }
+      curve = 'c' + curve; 
     }
+
+    curve = sjcl.ecc.curves[curve];
+    
+    if (curve === undefined) {
+      throw new sjcl.exception.invalid("no such curve");
+    }
+    
     sec = sec || sjcl.bn.random(curve.r, paranoia);
 
     var pub = curve.G.mult(sec);


### PR DESCRIPTION
I tried to generate ecc keys by k256 curve as below but it crashed.
``` javascript
var keys = sjcl.ecc.ecdsa.generateKeys('256k',6)
```
I found it dealt only with  numeric curve and I fixed it.